### PR TITLE
Add proxy and reversed proxy connections

### DIFF
--- a/contracts/contracts/Staking.sol
+++ b/contracts/contracts/Staking.sol
@@ -65,7 +65,8 @@ contract Staking is StakingInfra, LinearRewardCalculator {
     require(subscriptions[subscriber].startDate == 0, "Staking: this account has already staked");
 
     // transfer tokens from subscriber to the contract
-    require(erc20.transferFrom(subscriber, address(this), _amount), "Staking: Could not transfer tokens from subscriber");
+    require(erc20.transferFrom(subscriber, address(this), _amount),
+      "Staking: Could not transfer tokens from subscriber");
 
     uint256 maxReward = calculateReward(time, endDate, _amount);
     lockedTokens += _amount + maxReward;

--- a/plugin/src/models/Connection/BackgroundConnection.js
+++ b/plugin/src/models/Connection/BackgroundConnection.js
@@ -19,9 +19,9 @@ export default class BackgroundConnection {
   _handleMessage({ type, message }) {
     console.log("background -> content-script", { type, message });
 
-    if (type === Response.name) {
+    if (type === Response.NAME) {
       this._handleResponse(message);
-    } else if (type === Invokation.name) {
+    } else if (type === Invokation.NAME) {
       this._handleInvokation(message);
     } else {
       throw new Error(`Unexpected message ${message} of type ${type}`);
@@ -53,11 +53,11 @@ export default class BackgroundConnection {
     callback(...args)
       .then((value) => {
         const response = new Response(method, value, id);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       })
       .catch((error) => {
         const response = new Response(method, error, id, false);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       });
   }
 
@@ -79,7 +79,7 @@ export default class BackgroundConnection {
 
       this.responseCallbacks[id] = { resolve, reject };
 
-      this.postMessage(Invokation.name, message.serialize());
+      this.postMessage(Invokation.NAME, message.serialize());
     });
   }
 

--- a/plugin/src/models/Connection/BackgroundConnection.js
+++ b/plugin/src/models/Connection/BackgroundConnection.js
@@ -17,6 +17,7 @@ export default class BackgroundConnection {
   }
 
   _handleMessage({ type, message }) {
+    // TODO: Remove debug console.log
     console.log("background -> content-script", { type, message });
 
     if (type === Response.NAME) {

--- a/plugin/src/models/Connection/ContentScriptConnection.js
+++ b/plugin/src/models/Connection/ContentScriptConnection.js
@@ -33,6 +33,7 @@ export default class ContentScriptConnection {
   }
 
   _handleMessage(port, { type, message }) {
+    // TODO: Remove debug console.log
     console.log("content-script -> background", { type, message });
 
     if (type === Response.NAME) {

--- a/plugin/src/models/Connection/ContentScriptConnection.js
+++ b/plugin/src/models/Connection/ContentScriptConnection.js
@@ -33,6 +33,8 @@ export default class ContentScriptConnection {
   }
 
   _handleMessage(port, { type, message }) {
+    console.log("content-script -> background", { type, message });
+
     if (type === Response.name) {
       this._handleResponse(message);
     } else if (type === Invokation.name) {
@@ -61,7 +63,7 @@ export default class ContentScriptConnection {
   }
 
   _handleInvokation(port, msg) {
-    const { method, args, id } = msg;
+    const { method, args, id } = Invokation.parse(msg);
     const callback = this.invokationCallbacks[method];
 
     if (!callback) throw new Error(`Unexpected invokation method ${method}`);

--- a/plugin/src/models/Connection/ContentScriptConnection.js
+++ b/plugin/src/models/Connection/ContentScriptConnection.js
@@ -35,16 +35,16 @@ export default class ContentScriptConnection {
   _handleMessage(port, { type, message }) {
     console.log("content-script -> background", { type, message });
 
-    if (type === Response.name) {
+    if (type === Response.NAME) {
       this._handleResponse(message);
-    } else if (type === Invokation.name) {
+    } else if (type === Invokation.NAME) {
       this._handleInvokation(port, message);
     } else {
       throw new Error(`Unexpected message ${message} of type ${type}`);
     }
   }
 
-  _postMessage(id, type, message) {
+  postMessage(id, type, message) {
     if (this.ports[id]) {
       this.ports[id].postMessage({ type, message });
     }
@@ -71,11 +71,11 @@ export default class ContentScriptConnection {
     callback({ port, payload: args })
       .then((value) => {
         const response = new Response(method, value, id);
-        this._postMessage(port, Response.name, response.serialize());
+        this.postMessage(port, Response.NAME, response.serialize());
       })
       .catch((error) => {
         const response = new Response(method, error, id, false);
-        this._postMessage(port, Response.name, response.serialize());
+        this.postMessage(port, Response.NAME, response.serialize());
       });
   }
 
@@ -97,7 +97,13 @@ export default class ContentScriptConnection {
 
       this.responseCallbacks[id] = { message, resolve, reject };
 
-      this._postMessage(port, Invokation.name, message.serialize());
+      this.postMessage(port, Invokation.NAME, message.serialize());
+    });
+  }
+
+  listen(id) {
+    return new Promise((resolve, reject) => {
+      this.responseCallbacks[id] = { resolve, reject };
     });
   }
 }

--- a/plugin/src/models/Connection/ExtensionConnection.js
+++ b/plugin/src/models/Connection/ExtensionConnection.js
@@ -19,9 +19,9 @@ export default class ExtensionConnection {
   _handleMessage({ type, message }) {
     console.log("content-script -> inpage", { type, message });
 
-    if (type === Response.name) {
+    if (type === Response.NAME) {
       this._handleResponse(message);
-    } else if (type === Invokation.name) {
+    } else if (type === Invokation.NAME) {
       this._handleInvokation(message);
     } else {
       throw new Error(`Unexpected message ${message} of type ${type}`);
@@ -53,11 +53,11 @@ export default class ExtensionConnection {
     callback(...args)
       .then((value) => {
         const response = new Response(method, value, id);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       })
       .catch((error) => {
         const response = new Response(method, error, id, false);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       });
   }
 
@@ -79,7 +79,13 @@ export default class ExtensionConnection {
 
       this.responseCallbacks[id] = { message, resolve, reject };
 
-      this.postMessage(Invokation.name, message.serialize());
+      this.postMessage(Invokation.NAME, message.serialize());
+    });
+  }
+
+  listen(id) {
+    return new Promise((resolve, reject) => {
+      this.responseCallbacks[id] = { resolve, reject };
     });
   }
 }

--- a/plugin/src/models/Connection/ExtensionConnection.js
+++ b/plugin/src/models/Connection/ExtensionConnection.js
@@ -17,6 +17,7 @@ export default class ExtensionConnection {
   }
 
   _handleMessage({ type, message }) {
+    // TODO: Remove debug console.log
     console.log("content-script -> inpage", { type, message });
 
     if (type === Response.NAME) {

--- a/plugin/src/models/Connection/ExtensionConnection.js
+++ b/plugin/src/models/Connection/ExtensionConnection.js
@@ -5,24 +5,71 @@ import Response from "@models/Message/Response";
 
 export default class ExtensionConnection {
   constructor(params) {
-    this.stream = new LocalMessageDuplexStream(params);
-    this.callbacks = {};
+    this.extension = new LocalMessageDuplexStream(params);
+    this.responseCallbacks = {};
+    this.invokationCallbacks = {};
 
     this._setupEvents();
   }
 
   _setupEvents() {
-    this.stream.on("data", this._handleData.bind(this));
+    this.extension.on("data", this._handleMessage.bind(this));
   }
 
-  _handleData(data) {
-    const { value, id, success } = Response.parse(data);
-    const callback = this.callbacks[id];
+  _handleMessage({ type, message }) {
+    console.log("content-script -> inpage", { type, message });
 
-    if (!callback) return;
+    if (type === Response.name) {
+      this._handleResponse(message);
+    } else if (type === Invokation.name) {
+      this._handleInvokation(message);
+    } else {
+      throw new Error(`Unexpected message ${message} of type ${type}`);
+    }
+  }
+
+  postMessage(type, message) {
+    this.extension.write({ type, message });
+  }
+
+  _handleResponse(msg) {
+    const { value, id, success } = Response.parse(msg);
+    const callback = this.responseCallbacks[id];
+
+    if (!callback) throw new Error(`Unexpected response message ${msg}`);
 
     const { resolve, reject } = callback;
     success ? resolve(value) : reject(value);
+
+    delete this.responseCallbacks[id];
+  }
+
+  _handleInvokation(msg) {
+    const { method, args, id } = Invokation.parse(msg);
+    const callback = this.invokationCallbacks[method];
+
+    if (!callback) throw new Error(`Unexpected invokation method ${method}`);
+
+    callback(...args)
+      .then((value) => {
+        const response = new Response(method, value, id);
+        this.postMessage(Response.name, response.serialize());
+      })
+      .catch((error) => {
+        const response = new Response(method, error, id, false);
+        this.postMessage(Response.name, response.serialize());
+      });
+  }
+
+  on(method, callback) {
+    let promiseCallback = callback;
+
+    if (!callback.then) {
+      promiseCallback = async (...args) => callback(...args);
+    }
+
+    this.invokationCallbacks[method] = promiseCallback;
+    return this;
   }
 
   invoke(method, ...args) {
@@ -30,9 +77,9 @@ export default class ExtensionConnection {
       const message = new Invokation(method, args);
       const { id } = message;
 
-      this.callbacks[id] = { message, resolve, reject };
+      this.responseCallbacks[id] = { message, resolve, reject };
 
-      this.stream.write(message.serialize());
+      this.postMessage(Invokation.name, message.serialize());
     });
   }
 }

--- a/plugin/src/models/Connection/InpageConnection.js
+++ b/plugin/src/models/Connection/InpageConnection.js
@@ -17,6 +17,7 @@ export default class InpageConnection {
   }
 
   _handleMessage({ type, message }) {
+    // TODO: Remove debug console.log
     console.log("inpage -> content-script", { type, message });
 
     if (type === Response.NAME) {

--- a/plugin/src/models/Connection/InpageConnection.js
+++ b/plugin/src/models/Connection/InpageConnection.js
@@ -4,63 +4,88 @@ import Invokation from "@models/Message/Invokation";
 import Response from "@models/Message/Response";
 
 export default class InpageConnection {
-  constructor(params, background) {
-    this.stream = new LocalMessageDuplexStream(params);
-    this.proxiedMethods = new Set();
-    this.callbacks = {};
-    this.background = background;
+  constructor(inpageParams) {
+    this.inpage = new LocalMessageDuplexStream(inpageParams);
+    this.responseCallbacks = {};
+    this.invokationCallbacks = {};
 
     this._setupEvents();
   }
 
   _setupEvents() {
-    this.background.listen(this._handleMessage.bind(this));
-    this.stream.on("data", this._handleData.bind(this));
+    this.inpage.on("data", this._handleMessage.bind(this));
   }
 
-  // calls a saved callback and sends a response
-  _call(invokation) {
-    const { method, args, id } = invokation;
-    const callback = this.callbacks[method];
+  _handleMessage({ type, message }) {
+    console.log("inpage -> content-script", { type, message });
 
-    if (!callback) throw new Error(`Undefined method ${method}`);
-
-    const value = callback(...args);
-
-    const response = new Response(method, value, id);
-    this.stream.write(response.serialize());
+    if (type === Response.name) {
+      this._handleResponse(message);
+    } else if (type === Invokation.name) {
+      this._handleInvokation(message);
+    } else {
+      throw new Error(`Unexpected message ${message} of type ${type}`);
+    }
   }
 
-  // forwards messages to the background script
-  _forward(invokation) {
-    const { id } = invokation;
-
-    this.background.listen(id, this._handleMessage.bind(this));
-    this.background.invoke(invokation);
+  postMessage(type, message) {
+    this.inpage.write({ type, message });
   }
 
-  // handles data from the inpage script
-  _handleData(data) {
-    const invokation = Invokation.parse(data);
-    const { method } = invokation;
+  _handleResponse(msg) {
+    const { value, id, success } = Response.parse(msg);
+    const callback = this.responseCallbacks[id];
 
-    this.proxiedMethods.has(method)
-      ? this._forward(invokation)
-      : this._call(invokation);
+    if (!callback) throw new Error(`Unexpected response message ${msg}`);
+
+    const { resolve, reject } = callback;
+    success ? resolve(value) : reject(value);
+
+    delete this.responseCallbacks[id];
   }
 
-  // handles messages from the background script
-  _handleMessage(msg) {
-    this.stream.write(msg.serialize());
-  }
+  _handleInvokation(msg) {
+    const { method, args, id } = Invokation.parse(msg);
+    const callback = this.invokationCallbacks[method];
 
-  proxy(method) {
-    this.proxiedMethods.add(method);
-    return this;
+    if (!callback) throw new Error(`Unexpected invokation method ${method}`);
+
+    callback(...args)
+      .then((value) => {
+        const response = new Response(method, value, id);
+        this.postMessage(Response.name, response.serialize());
+      })
+      .catch((error) => {
+        const response = new Response(method, error, id, false);
+        this.postMessage(Response.name, response.serialize());
+      });
   }
 
   on(method, callback) {
-    this.callbacks[method] = callback;
+    let promiseCallback = callback;
+
+    if (!callback.then) {
+      promiseCallback = async (...args) => callback(...args);
+    }
+
+    this.invokationCallbacks[method] = promiseCallback;
     return this;
+  }
+
+  invoke(method, ...args) {
+    return new Promise((resolve, reject) => {
+      const message = new Invokation(method, args);
+      const { id } = message;
+
+      this.responseCallbacks[id] = { resolve, reject };
+
+      this.postMessage(Invokation.name, message.serialize());
+    });
+  }
+
+  listen(id) {
+    return new Promise((resolve, reject) => {
+      this.responseCallbacks[id] = { resolve, reject };
+    });
   }
 }

--- a/plugin/src/models/Connection/InpageConnection.js
+++ b/plugin/src/models/Connection/InpageConnection.js
@@ -19,9 +19,9 @@ export default class InpageConnection {
   _handleMessage({ type, message }) {
     console.log("inpage -> content-script", { type, message });
 
-    if (type === Response.name) {
+    if (type === Response.NAME) {
       this._handleResponse(message);
-    } else if (type === Invokation.name) {
+    } else if (type === Invokation.NAME) {
       this._handleInvokation(message);
     } else {
       throw new Error(`Unexpected message ${message} of type ${type}`);
@@ -53,11 +53,11 @@ export default class InpageConnection {
     callback(...args)
       .then((value) => {
         const response = new Response(method, value, id);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       })
       .catch((error) => {
         const response = new Response(method, error, id, false);
-        this.postMessage(Response.name, response.serialize());
+        this.postMessage(Response.NAME, response.serialize());
       });
   }
 
@@ -79,7 +79,7 @@ export default class InpageConnection {
 
       this.responseCallbacks[id] = { resolve, reject };
 
-      this.postMessage(Invokation.name, message.serialize());
+      this.postMessage(Invokation.NAME, message.serialize());
     });
   }
 

--- a/plugin/src/models/Connection/ProxyConnection.js
+++ b/plugin/src/models/Connection/ProxyConnection.js
@@ -32,6 +32,7 @@ export default class ProxyConnection {
       return new Promise((resolve, reject) => {
         const invokation = new Invokation(method, args);
 
+        // TODO: Remove debug console.log
         console.log("proxy: inpage -> background", invokation);
 
         // forward message to background
@@ -54,6 +55,7 @@ export default class ProxyConnection {
       return new Promise((resolve, reject) => {
         const invokation = new Invokation(method, args);
 
+        // TODO: Remove debug console.log
         console.log("proxy: background -> inpage", invokation);
 
         // forward message to inpage

--- a/plugin/src/models/Connection/ProxyConnection.js
+++ b/plugin/src/models/Connection/ProxyConnection.js
@@ -8,7 +8,7 @@ export default class ProxyConnection {
 
   // forwards messages to the inpage script
   forwardInpage(invokation) {
-    this.postInpageMessage(Invokation.name, invokation.serialize());
+    this.postInpageMessage(Invokation.NAME, invokation.serialize());
   }
 
   // post a message to the inpage script via stream
@@ -18,7 +18,7 @@ export default class ProxyConnection {
 
   // forwards messages to the background script
   forwardBackground(invokation) {
-    this.postBackgroundMessage(Invokation.name, invokation.serialize());
+    this.postBackgroundMessage(Invokation.NAME, invokation.serialize());
   }
 
   // post a message to the background script via chrome ports

--- a/plugin/src/models/Connection/ProxyConnection.js
+++ b/plugin/src/models/Connection/ProxyConnection.js
@@ -1,0 +1,72 @@
+import Invokation from "@models/Message/Invokation";
+
+export default class ProxyConnection {
+  constructor(inpage, background) {
+    this.inpage = inpage;
+    this.background = background;
+  }
+
+  // forwards messages to the inpage script
+  forwardInpage(invokation) {
+    this.postInpageMessage(Invokation.name, invokation.serialize());
+  }
+
+  // post a message to the inpage script via stream
+  postInpageMessage(type, message) {
+    this.inpage.postMessage(type, message);
+  }
+
+  // forwards messages to the background script
+  forwardBackground(invokation) {
+    this.postBackgroundMessage(Invokation.name, invokation.serialize());
+  }
+
+  // post a message to the background script via chrome ports
+  postBackgroundMessage(type, message) {
+    this.background.postMessage(type, message);
+  }
+
+  // proxy messages froms inpage to background
+  proxy(method) {
+    this.inpage.on(method, (...args) => {
+      return new Promise((resolve, reject) => {
+        const invokation = new Invokation(method, args);
+
+        console.log("proxy: inpage -> background", invokation);
+
+        // forward message to background
+        this.forwardBackground(invokation);
+
+        // listen for background reply
+        this.background
+          .listen(invokation.id)
+          .then((value) => resolve(value))
+          .catch((error) => reject(error));
+      });
+    });
+
+    return this;
+  }
+
+  // proxy messages froms background to inpage
+  reversedProxy(method) {
+    this.background.on(method, (...args) => {
+      return new Promise((resolve, reject) => {
+        const invokation = new Invokation(method, args);
+
+        console.log("proxy: background -> inpage", invokation);
+
+        // forward message to inpage
+        this.forwardInpage(invokation);
+
+        // listen for inpage reply
+        this.inpage
+          .listen(invokation.id)
+          .then((value) => resolve(value))
+          .catch((error) => reject(error));
+      });
+    });
+
+    return this;
+  }
+}

--- a/plugin/src/models/Connection/types.js
+++ b/plugin/src/models/Connection/types.js
@@ -1,9 +1,0 @@
-import mirrorCreator from "mirror-creator";
-
-const types = mirrorCreator([
-  "CONFIRM_CREDENTIAL",
-  "COMMIT_CREDENTIAL",
-  "VERIFY_CONNECTION",
-]);
-
-export default types;

--- a/plugin/src/models/Connection/types.ts
+++ b/plugin/src/models/Connection/types.ts
@@ -1,0 +1,7 @@
+enum ConnectionTypes {
+  CONFIRM_CREDENTIAL = "CONFIRM_CREDENTIAL",
+  COMMIT_CREDENTIAL = "COMMIT_CREDENTIAL",
+  VERIFY_CONNECTION = "VERIFY_CONNECTION",
+}
+
+export default ConnectionTypes;

--- a/plugin/src/models/Fractal/index.js
+++ b/plugin/src/models/Fractal/index.js
@@ -2,12 +2,24 @@ import ExtensionConnection from "@models/Connection/ExtensionConnection";
 import { extension } from "@models/Connection/params";
 import types from "@models/Connection/types";
 
-const stream = new ExtensionConnection(extension);
+const extensionConnection = new ExtensionConnection(extension);
 
 const confirmCredential = (...args) =>
-  stream.invoke(types.CONFIRM_CREDENTIAL, ...args);
+  extensionConnection.invoke(types.CONFIRM_CREDENTIAL, ...args);
 const verifyConnection = (...args) =>
-  stream.invoke(types.VERIFY_CONNECTION, ...args);
+  extensionConnection.invoke(types.VERIFY_CONNECTION, ...args);
+
+extensionConnection.on(types.COMMIT_CREDENTIAL, async (credential) => {
+  console.log("Commiting the credential", credential);
+
+  // Dummy wait for simulating credential transaction commit
+  await new Promise((resolve) => setTimeout(() => resolve(), 3000));
+
+  const transactionHash =
+    "0x9ed9d53fddb685493ef99f4ce622f15573966dbb6031ff55a828b76445cdb7ba";
+
+  return transactionHash;
+});
 
 const Fractal = {
   confirmCredential,

--- a/plugin/src/models/Message/Invokation.js
+++ b/plugin/src/models/Message/Invokation.js
@@ -1,6 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 
+import ResponseTypes from "@models/Message/types";
+
 export default class Invokation {
+  static NAME = ResponseTypes.INVOKATION;
+
   constructor(method, args = [], id = null) {
     this.id = id || uuidv4();
     this.method = method;

--- a/plugin/src/models/Message/Response.js
+++ b/plugin/src/models/Message/Response.js
@@ -1,6 +1,12 @@
+import { v4 as uuidv4 } from "uuid";
+
+import ResponseTypes from "@models/Message/types";
+
 export default class Response {
-  constructor(method, value, id, success = true) {
-    this.id = id || Date.now();
+  static NAME = ResponseTypes.RESPONSE;
+
+  constructor(method, value, id = null, success = true) {
+    this.id = id || uuidv4();
     this.method = method;
     this.value = value;
     this.success = success;

--- a/plugin/src/models/Message/types.ts
+++ b/plugin/src/models/Message/types.ts
@@ -1,0 +1,6 @@
+enum MessageTypes {
+  INVOKATION = "INVOKATION",
+  RESPONSE = "RESPONSE",
+}
+
+export default MessageTypes;

--- a/plugin/src/scripts/background/index.js
+++ b/plugin/src/scripts/background/index.js
@@ -22,46 +22,52 @@ async function init() {
     types.CONFIRM_CREDENTIAL,
     ({ port, payload: [content, target] }) =>
       new Promise((resolve, reject) => {
-        const request = {
-          id: uuidv4(),
-          requester: target.address,
-          content: {
-            attester: content.attestation.owner,
-            claimer: content.request.claim.owner,
-            properties: content.request.claim.contents,
-            ctype: content.request.claim.cTypeHash,
-            claim: content,
-          },
-          type: RequestTypes.CONFIRM_CREDENTIAL,
-        };
+        try {
+          const request = {
+            id: uuidv4(),
+            requester: target.address,
+            content: {
+              attester: content.attestation.owner,
+              claimer: content.request.claim.owner,
+              properties: content.request.claim.contents,
+              ctype: content.request.claim.cTypeHash,
+              claim: content,
+            },
+            type: RequestTypes.CONFIRM_CREDENTIAL,
+          };
 
-        UserStore.store.dispatch(requestsActions.addRequest(request));
+          UserStore.store.dispatch(requestsActions.addRequest(request));
 
-        // create callbacks
-        const onAccept = async (acceptedRequest) => {
-          // commit credential to the blockchain
-          const transactionHash = await contentScript.invoke(
-            port,
-            types.COMMIT_CREDENTIAL,
-            acceptedRequest.content,
+          // create callbacks
+          const onAccept = async (acceptedRequest) => {
+            // commit credential to the blockchain
+            const transactionHash = await contentScript.invoke(
+              port,
+              types.COMMIT_CREDENTIAL,
+              acceptedRequest.content,
+            );
+
+            resolve(transactionHash);
+          };
+          const onDecline = () => reject(RequestStatus.DECLINED);
+
+          const onTimeout = () => {
+            UserStore.store.dispatch(requestsActions.removeRequest(request.id));
+
+            reject(RequestStatus.TIMED_OUT);
+          };
+
+          requestsWatcher.listenForRequest(
+            request.id,
+            onAccept,
+            onDecline,
+            onTimeout,
           );
-
-          resolve(transactionHash);
-        };
-        const onDecline = () => reject(RequestStatus.DECLINED);
-
-        const onTimeout = () => {
-          UserStore.store.dispatch(requestsActions.removeRequest(request.id));
-
-          reject(RequestStatus.TIMED_OUT);
-        };
-
-        requestsWatcher.listenForRequest(
-          request.id,
-          onAccept,
-          onDecline,
-          onTimeout,
-        );
+        } catch (error) {
+          console.log(error);
+          console.error(error);
+          reject(error);
+        }
       }),
   );
 }

--- a/plugin/src/scripts/background/index.js
+++ b/plugin/src/scripts/background/index.js
@@ -64,7 +64,6 @@ async function init() {
             onTimeout,
           );
         } catch (error) {
-          console.log(error);
           console.error(error);
           reject(error);
         }

--- a/plugin/src/scripts/contentScript/index.js
+++ b/plugin/src/scripts/contentScript/index.js
@@ -2,7 +2,9 @@
 
 import InpageConnection from "@models/Connection/InpageConnection";
 import BackgroundConnection from "@models/Connection/BackgroundConnection";
-import { inpage } from "@models/Connection/params";
+import ProxyConnection from "@models/Connection/ProxyConnection";
+
+import { inpage, background } from "@models/Connection/params";
 import types from "@models/Connection/types";
 
 import { injectScript } from "./injector";
@@ -10,25 +12,19 @@ import { injectScript } from "./injector";
 const sdk = chrome.runtime.getURL("sdk.bundle.js");
 injectScript(sdk);
 
-const backgroundConnection = new BackgroundConnection();
-const inpageConnection = new InpageConnection(inpage, backgroundConnection);
+const inpageConnection = new InpageConnection(inpage);
+const backgroundConnection = new BackgroundConnection(background);
+const proxyConnection = new ProxyConnection(
+  inpageConnection,
+  backgroundConnection,
+);
 
-inpageConnection
-  .on(types.VERIFY_CONNECTION, () => {
-    const { version } = chrome.runtime.getManifest();
-    return version;
-  })
-  .proxy(types.CONFIRM_CREDENTIAL)
-  .proxy(types.REQUEST_CREDENTIAL);
-
-backgroundConnection.on(types.COMMIT_CREDENTIAL, async (credential) => {
-  console.log("Commiting the credential", credential);
-
-  // Dummy wait for simulating credential transaction commit
-  await new Promise((resolve) => setTimeout(() => resolve(), 3000));
-
-  const transactionHash =
-    "0x9ed9d53fddb685493ef99f4ce622f15573966dbb6031ff55a828b76445cdb7ba";
-
-  return transactionHash;
+inpageConnection.on(types.VERIFY_CONNECTION, () => {
+  const { version } = chrome.runtime.getManifest();
+  return version;
 });
+
+proxyConnection
+  .proxy(types.CONFIRM_CREDENTIAL)
+  .proxy(types.REQUEST_CREDENTIAL)
+  .reversedProxy(types.COMMIT_CREDENTIAL);


### PR DESCRIPTION
This PR adds a proxy connection to enable messages being transmitted from the Inpage to the Background, and vice-versa.

This will enable the following messaging flows:
- From `Inpage` to `Content-Script`
- From `Inpage` to `Background` (Proxy through Content-Script)

- From `Background` to `Content-Script`
- From `Background` to `Inpage` (Reversed-Proxy through Content-Script)

- From `Content-Script` to `Inpage`
- From `Content-Script` to `Background`

> Note: A bunch of code is repeated through the `*Connection` classes. I wanted to use classes inheritance and typescript to avoid this, but the PR was getting too big. This will be done in the upcoming PR.