### PR TITLE
Add double hashing password

### DIFF
--- a/plugin/src/scripts/background/aliases/AuthAliases/index.js
+++ b/plugin/src/scripts/background/aliases/AuthAliases/index.js
@@ -23,9 +23,11 @@ export const signUp = () => {
       // init the encrypted user store
       await Store.init(registeredPassword);
 
-      // save the hashed password for authentication purposes
+      // save a double hash password for authentication purposes
       const hashedPassword = (
-        await UserStore.getHashedPassword(registeredPassword)
+        await UserStore.getHashedPassword(registeredPassword).then(
+          UserStore.getHashedPassword,
+        )
       ).toString();
       dispatch(authActions.setHashedPassword(hashedPassword));
 
@@ -52,7 +54,9 @@ export const signIn = ({ payload: attemptedPassword }) => {
 
       // Hash attempted password
       const hashedAttemptedPassword = (
-        await UserStore.getHashedPassword(attemptedPassword)
+        await UserStore.getHashedPassword(attemptedPassword).then(
+          UserStore.getHashedPassword,
+        )
       ).toString();
 
       // Compare passwords hashes


### PR DESCRIPTION
This PR fixes a security problem. 

We are using the user's password to create a password hash to encrypt and decrypt the store. This password hash is being saved alongside the encrypted state so we can later confirm if the password is correct.

This PR changes the stored hash password to a different hash that is the result of double hashing the encryption password.