### PR TITLE
Disables staking tab

### DIFF
--- a/plugin/src/popup/components/Home/index.tsx
+++ b/plugin/src/popup/components/Home/index.tsx
@@ -32,7 +32,7 @@ function Home(props: HomeProps) {
     {
       id: "staking-tab",
       label: "Staking",
-      props: { stakingDetails, stakingStatus, onClick },
+      props: { stakingDetails, stakingStatus, onClick, disabled: true },
       component: Staking,
     },
   ];

--- a/plugin/src/popup/components/common/TabButton/index.tsx
+++ b/plugin/src/popup/components/common/TabButton/index.tsx
@@ -18,6 +18,7 @@ const RootContainer = styled.button<{
   border-left: 1px solid var(--c-orange);
 
   padding: var(--s-14) var(--s-35);
+  height: 49px;
 
   display: flex;
   flex-direction: row;
@@ -28,8 +29,21 @@ const RootContainer = styled.button<{
   ${(props) =>
     props.disabled &&
     css`
-      opacity: 0.6;
+      display: flex;
+      flex-direction: column;
       cursor: default;
+
+      > span:first-child {
+        opacity: 0.5;
+        line-height: 24px;
+      }
+
+      > span:last-child {
+        font-size: 12px;
+        line-height: 16px;
+        font-variant: all-small-caps;
+        color: var(--c-white);
+      }
     `}
 
   ${(props) =>
@@ -78,7 +92,8 @@ function TabButton(
       selected={selected}
       {...otherProps}
     >
-      {label}
+      <span>{label}</span>
+      {disabled && <span>Coming soon</span>}
     </RootContainer>
   );
 }

--- a/plugin/src/popup/components/common/Tabs/index.tsx
+++ b/plugin/src/popup/components/common/Tabs/index.tsx
@@ -38,7 +38,7 @@ function Tabs(props: TabsProps & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <RootContainer {...otherProps}>
       <TabsButtonsContainer>
-        {tabs.map(({ id, label }, index) => (
+        {tabs.map(({ id, label, props: { disabled } }, index) => (
           <TabButton
             key={id}
             index={index}
@@ -46,6 +46,7 @@ function Tabs(props: TabsProps & React.HTMLAttributes<HTMLDivElement>) {
             onClick={() => setSelected(id)}
             selected={id === selected}
             label={label}
+            disabled={disabled}
           />
         ))}
       </TabsButtonsContainer>


### PR DESCRIPTION
I didn't have much time to see the style patterns the app is using, so:
* I've hardcoded some CSS values and
*   used `span` in styled-components (never used it, so not sure if it's a best practice)

![Screenshot 2021-05-05 at 11 47 51](https://user-images.githubusercontent.com/448574/117130297-c3b4b900-ad97-11eb-9fc7-9364432ccf57.png)
