### PR TITLE
Add missing storage permission

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -49,5 +49,5 @@
     "128": "img/icon_128.png",
     "512": "img/icon_512.png"
   },
-  "permissions": ["tabs", "unlimitedStorage"]
+  "permissions": ["tabs", "storage", "unlimitedStorage"]
 }


### PR DESCRIPTION
Besides the **unlimitedStorage** we also need the **storage** permission otherwise we run into the error `TypeError: Cannot read property 'local' of undefined` when calling any method from `chrome.storage.local.*`.

This PRs adds it back.