### PR TITLE
Load config from maguro

### DIFF
--- a/src/popup/containers/HomeScreen/index.tsx
+++ b/src/popup/containers/HomeScreen/index.tsx
@@ -1,16 +1,18 @@
-import { useUserSelector } from "@redux/stores/user/context";
-
 import Tabs from "@popup/components/common/Tabs";
 import Credentials from "@popup/components/Credentials";
 import Protocol from "@popup/components/Protocol";
 import { withNavBar } from "@popup/components/common/NavBar";
 
+import { useAppSelector } from "@redux/stores/application/context";
+import { getProtocolEnabled } from "@redux/stores/application/reducers/app/selectors";
+import { useUserSelector } from "@redux/stores/user/context";
 import { getCredentials } from "@redux/stores/user/reducers/credentials/selectors";
 import { getRequests } from "@redux/stores/user/reducers/requests/selectors";
 
 function Home() {
   const requests = useUserSelector(getRequests);
   const credentials = useUserSelector(getCredentials);
+  const protocolEnabled = useAppSelector(getProtocolEnabled);
 
   const tabs = [
     {
@@ -24,6 +26,7 @@ function Home() {
       label: "Protocol",
       props: {},
       component: Protocol,
+      disabled: !protocolEnabled,
     },
   ];
 

--- a/src/redux/stores/application/aliases/AppAliases/index.js
+++ b/src/redux/stores/application/aliases/AppAliases/index.js
@@ -1,6 +1,7 @@
 import appActions, { appTypes } from "@redux/stores/application/reducers/app";
 
 import CredentialsPolling from "@models/Polling/CredentialsPolling";
+import MaguroService from "@services/MaguroService";
 
 export const startup = () => {
   return async (dispatch) => {
@@ -11,7 +12,11 @@ export const startup = () => {
     // eslint-disable-next-line no-undef
     const { version } = chrome.runtime.getManifest();
 
+    const { protocol_enabled: protocolEnabled } =
+      await MaguroService.getConfig();
+
     dispatch(appActions.setVersion(version));
+    dispatch(appActions.setProtocolEnabled(protocolEnabled));
     dispatch(appActions.setLaunched(true));
   };
 };

--- a/src/redux/stores/application/reducers/app/index.js
+++ b/src/redux/stores/application/reducers/app/index.js
@@ -7,6 +7,7 @@ const types = mirrorCreator([
   "SET_SETUP",
   "SET_STATUS",
   "SET_VERSION",
+  "SET_PROTOCOL_ENABLED",
   "SET_PROTOCOL_OPT_IN",
 ]);
 
@@ -16,6 +17,7 @@ export const creators = createActions(
   types.SET_SETUP,
   types.SET_STATUS,
   types.SET_VERSION,
+  types.SET_PROTOCOL_ENABLED,
   types.SET_PROTOCOL_OPT_IN,
 );
 
@@ -24,6 +26,7 @@ export const initialState = {
   setup: false,
   version: "",
   protocolOptIn: false,
+  protocolEnabled: false,
 };
 
 export const reducer = handleActions(
@@ -42,6 +45,11 @@ export const reducer = handleActions(
       Object.freeze({
         ...state,
         version,
+      }),
+    [types.SET_PROTOCOL_ENABLED]: (state, { payload: protocolEnabled }) =>
+      Object.freeze({
+        ...state,
+        protocolEnabled,
       }),
     [types.SET_PROTOCOL_OPT_IN]: (state, { payload: protocolOptIn }) =>
       Object.freeze({
@@ -63,6 +71,7 @@ export async function store(state) {
   return {
     setup: state.setup,
     protocolOptIn: state.protocolOptIn,
+    protocolEnabled: state.protocolEnabled,
   };
 }
 

--- a/src/redux/stores/application/reducers/app/selectors.js
+++ b/src/redux/stores/application/reducers/app/selectors.js
@@ -15,6 +15,11 @@ export const getVersion = createSelector(
   (app) => app.version,
 );
 
+export const getProtocolEnabled = createSelector(
+  (state) => state.app,
+  (app) => app.protocolEnabled,
+);
+
 export const getProtocolOptIn = createSelector(
   (state) => state.app,
   (app) => app.protocolOptIn,

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -78,4 +78,8 @@ export default class MaguroService {
       JSON.stringify({ linked_address: address }),
     );
   }
+
+  public static getConfig() {
+    return this.callApi("config", "GET", null);
+  }
 }


### PR DESCRIPTION
Why:

* We want the config coming from the protocol being enabled or not to
  come from Maguro.
* This allows us to control when the testnet becomes live and available
  for everyone, instead of relying on an approval from Google and users
  to update accordingly.