### PR TITLE
Use more meaningful status and error messages

### DIFF
--- a/src/redux/stores/user/reducers/protocol/index.js
+++ b/src/redux/stores/user/reducers/protocol/index.js
@@ -4,21 +4,32 @@ import { createActions, handleActions } from "redux-actions";
 const types = mirrorCreator([
   "SET_MNEMONIC",
   "SET_REGISTERED_FOR_MINTING",
-  "SET_REGISTRATION_SUCCESS",
+  "SET_REGISTRATION_STATE",
+  "SET_REGISTRATION_ERROR",
   "CREATE_WALLET",
 ]);
+
+const registrationTypes = {
+  STARTED: "STARTED",
+  ADDRESS_GENERATED: "ADDRESS_GENERATED",
+  IDENTITY_REGISTERED: "IDENTITY_REGISTERED",
+  MINTING_REGISTERED: "MINTING_REGISTERED",
+  COMPLETED: "COMPLETED",
+};
 
 export const creators = createActions(
   types.SET_MNEMONIC,
   types.SET_REGISTERED_FOR_MINTING,
-  types.SET_REGISTRATION_SUCCESS,
+  types.SET_REGISTRATION_STATE,
+  types.SET_REGISTRATION_ERROR,
   types.CREATE_WALLET,
 );
 
 export const initialState = {
   mnemonic: null,
   isRegisteredForMinting: false,
-  registrationSuccess: true,
+  registrationState: null,
+  registrationError: false,
 };
 
 export const reducer = handleActions(
@@ -38,13 +49,16 @@ export const reducer = handleActions(
         isRegisteredForMinting,
       }),
 
-    [types.SET_REGISTRATION_SUCCESS]: (
-      state,
-      { payload: registrationSuccess },
-    ) =>
+    [types.SET_REGISTRATION_STATE]: (state, { payload: registrationState }) =>
       Object.freeze({
         ...state,
-        registrationSuccess,
+        registrationState,
+      }),
+
+    [types.SET_REGISTRATION_ERROR]: (state, { payload: registrationError }) =>
+      Object.freeze({
+        ...state,
+        registrationError,
       }),
   },
   initialState,
@@ -61,10 +75,13 @@ export async function store(state) {
   return {
     mnemonic: state.mnemonic,
     isRegisteredForMinting: state.isRegisteredForMinting,
-    registrationSuccess: state.registrationSuccess,
+    registrationState: state.registrationState,
+    registrationError: state.registrationError,
   };
 }
 
 export const protocolTypes = types;
+
+export const protocolRegistrationTypes = registrationTypes;
 
 export default creators;

--- a/src/redux/stores/user/reducers/protocol/selectors.js
+++ b/src/redux/stores/user/reducers/protocol/selectors.js
@@ -13,7 +13,12 @@ export const isRegisteredForMinting = createSelector(
   (protocol) => protocol.registeredForMinting,
 );
 
-export const isRegistered = createSelector(
+export const getRegistrationState = createSelector(
   (state) => state.protocol,
-  (protocol) => protocol.registrationSuccess,
+  (protocol) => protocol.registrationState,
+);
+
+export const hasRegistrationErrored = createSelector(
+  (state) => state.protocol,
+  (protocol) => protocol.registrationError,
 );

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -6,6 +6,8 @@ import Environment from "@environment/index";
 import CatfishService from "@services/CatfishService";
 import HttpService from "@services/HttpService";
 
+const HTTP_TIMEOUT = 5 * 60 * 1000; // 5 minutes timeout
+
 export default class MaguroService {
   private static ensureAuthorization(
     headers: Record<string, string>,
@@ -35,6 +37,7 @@ export default class MaguroService {
       method,
       body,
       headersWithAuth,
+      HTTP_TIMEOUT,
     );
 
     if (!response.ok) {


### PR DESCRIPTION
Why:

* We want something less generic rather than just "Something went wrong".

This change addresses the need by:

* Tracking the status of the registration process.
* Displaying appropriate messages according to that.

<img width="395" alt="image" src="https://user-images.githubusercontent.com/4325027/128854155-6a1d46bd-4bd9-4f29-add0-d26260320479.png">

Besides the error messages, this PR also allows the user to automatically see updates to their registration process: "Generating address..." -> "Registering identity..." -> "Registering for minting..."