### PR TITLE
Fix disabled Protocol tab flickering

### DIFF
--- a/src/popup/containers/HomeScreen/index.tsx
+++ b/src/popup/containers/HomeScreen/index.tsx
@@ -5,12 +5,24 @@ import Tabs from "@popup/components/common/Tabs";
 import Protocol from "@popup/components/Protocol";
 import MaguroService from "@services/MaguroService";
 
+import {
+  useAppDispatch,
+  useAppSelector,
+} from "@redux/stores/application/context";
+import { getProtocolEnabled } from "@redux/stores/application/reducers/app/selectors";
+import appActions from "@redux/stores/application/reducers/app";
+
 interface HomeScreenProps {
   credentials: (props: any) => JSX.Element;
 }
 
 function HomeScreen({ credentials }: HomeScreenProps) {
-  const [protocolEnabled, setProtocolEnabled] = useState<boolean>(false);
+  const protocolEnabledConfig = useAppSelector(getProtocolEnabled);
+  const appDispatch = useAppDispatch();
+
+  const [protocolEnabled, setProtocolEnabled] = useState<boolean>(
+    protocolEnabledConfig,
+  );
 
   useEffect(() => {
     (async () => {
@@ -18,6 +30,7 @@ function HomeScreen({ credentials }: HomeScreenProps) {
 
       const config = await MaguroService.getConfig();
       setProtocolEnabled(config.protocol_enabled);
+      appDispatch(appActions.setProtocolEnabled(config.protocol_enabled));
     })();
   });
 


### PR DESCRIPTION
Following #95, we were checking the config on each render, however we
gave it a default `false` value.

Since the React app only loads after the config is loaded, we can use
that value as the initial `useState` value and update it if the protocol
becomes enabled.