### PR TITLE
Prevent minting errors when user isn't opted in

### DIFF
--- a/src/scripts/background/connection/callbacks/ProtocolCallbacks.ts
+++ b/src/scripts/background/connection/callbacks/ProtocolCallbacks.ts
@@ -4,8 +4,14 @@ import { DataHost } from "@services/DataHost";
 import storageService from "@services/StorageService";
 import { MintingRegistrar } from "@services/MintingRegistrar";
 import environment from "@environment/index";
+import { getProtocolOptIn } from "@redux/stores/application/reducers/app/selectors";
+import AppStore from "@redux/stores/application";
 
 export async function addWebpage([url]: [string]): Promise<void> {
+  const optedIn = getProtocolOptIn(AppStore.getStore().getState());
+
+  if (!optedIn) return;
+
   await DataHost.instance().storeFact({
     pageView: {
       url,


### PR DESCRIPTION
Why:

* When the user hasn't opted-in, we're still trying to register them for
  minting.
* This is causing weird errors in the background.

This change addresses the need by:

* Only registering if the user has opted in to the protocol.