### PR TITLE
Disconnect from protocol node after doing minting registration

### DIFF
--- a/src/services/MintingRegistrar.ts
+++ b/src/services/MintingRegistrar.ts
@@ -33,6 +33,7 @@ export class MintingRegistrar {
         "minting_registrar/last_check",
         now.toString(),
       );
+      await protocol.disconnect();
     });
   }
 }

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -39,6 +39,10 @@ export default class ProtocolService {
     return new ProtocolService(api, signer);
   }
 
+  public async disconnect() {
+    await this.api.disconnect();
+  }
+
   public constructor(api: ApiPromise, signer: KeyringPair) {
     this.api = api;
     this.signer = signer;


### PR DESCRIPTION
The MintingRegistrar runs on every page the user opens. This was causing dozens of long-lived connections per IP to the blockchain nodes.