### PR TITLE
Make extrinsic registration more robust

### DIFF
--- a/src/services/DataHost.ts
+++ b/src/services/DataHost.ts
@@ -58,7 +58,9 @@ export class DataHost {
     return this.array().iterBack();
   }
 
-  async extensionProof(latestProof: string|null): Promise<string | undefined> {
+  async extensionProof(
+    latestProof: string | null,
+  ): Promise<string | undefined> {
     const allItems = [];
     for await (let item of this.array().iter()) {
       allItems.push(item);
@@ -70,7 +72,9 @@ export class DataHost {
     if (latestProof == null) {
       return hexPrefix(prune_balanced(currentTree)!);
     } else {
-      const previousTree = latestProof.includes('x') ? latestProof.split('x')[1] : latestProof;
+      const previousTree = latestProof.includes("x")
+        ? latestProof.split("x")[1]
+        : latestProof;
       const proof = strict_extension_proof(currentTree, previousTree);
       return proof && hexPrefix(proof);
     }

--- a/src/services/DataHost.ts
+++ b/src/services/DataHost.ts
@@ -58,7 +58,7 @@ export class DataHost {
     return this.array().iterBack();
   }
 
-  async extensionProof(): Promise<[number, string] | undefined> {
+  async extensionProof(latestProof: string|null): Promise<string | undefined> {
     const allItems = [];
     for await (let item of this.array().iter()) {
       allItems.push(item);
@@ -67,27 +67,13 @@ export class DataHost {
 
     const currentTree = buildTree(allItems.map((i) => JSON.stringify(i)));
 
-    const maybeLastProofLength = await this.metadata.getItem(
-      this.key("last_proof_index"),
-    );
-    if (maybeLastProofLength == null) {
-      return [allItems.length, hexPrefix(prune_balanced(currentTree)!)];
+    if (latestProof == null) {
+      return hexPrefix(prune_balanced(currentTree)!);
+    } else {
+      const previousTree = latestProof.includes('x') ? latestProof.split('x')[1] : latestProof;
+      const proof = strict_extension_proof(currentTree, previousTree);
+      return proof && hexPrefix(proof);
     }
-    const lastProofLength = parseInt(maybeLastProofLength);
-    if (lastProofLength === allItems.length) return;
-
-    const previousTree = buildTree(
-      allItems.slice(0, lastProofLength).map((i) => JSON.stringify(i)),
-    );
-    const proof = strict_extension_proof(currentTree, previousTree)!;
-    return [allItems.length, hexPrefix(proof)];
-  }
-
-  async setLastProofLength(length: number) {
-    await this.metadata.setItem(
-      this.key("last_proof_index"),
-      length.toString(),
-    );
   }
 }
 

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -66,13 +66,14 @@ export default class ProtocolService {
     // Blue-green strategy handling migration of blockchain storage.
     try {
       // Will be long-term code.
-      const dataset =
-        await this.api.query.fractalMinting.idDatasets(this.address(), fractalId);
+      const dataset = await this.api.query.fractalMinting.idDatasets(
+        this.address(),
+        fractalId,
+      );
       return dataset.toHuman() as string | null;
     } catch (e) {
       // TODO(shelbyd): Delete this after rollout of storage change.
-      const dataset =
-        await this.api.query.fractalMinting.idDatasets(fractalId);
+      const dataset = await this.api.query.fractalMinting.idDatasets(fractalId);
       return dataset.toHuman() as string | null;
     }
   }
@@ -82,23 +83,26 @@ export default class ProtocolService {
     const txn = this.api.tx.fractalMinting.registerForMinting(null, proof);
 
     return new Promise(async (resolve, reject) => {
-      const unsub = await txn.signAndSend(this.signer, ({ events = [], status }) => {
-        console.log(`Extrinsic status: ${status}`);
-        if (!status.isFinalized) return;
+      const unsub = await txn.signAndSend(
+        this.signer,
+        ({ events = [], status }) => {
+          console.log(`Extrinsic status: ${status}`);
+          if (!status.isFinalized) return;
 
-        events.forEach(({ event: { data, method, section } }) => {
-          if (section !== 'system') return;
+          events.forEach(({ event: { data, method, section } }) => {
+            if (section !== "system") return;
 
-          if (method === 'ExtrinsicSuccess') {
-            resolve(status.asFinalized.toHuman() as string);
-          }
-          if (method === 'ExtrinsicFailed') {
-            reject(data);
-          }
-        });
+            if (method === "ExtrinsicSuccess") {
+              resolve(status.asFinalized.toHuman() as string);
+            }
+            if (method === "ExtrinsicFailed") {
+              reject(data);
+            }
+          });
 
-        unsub();
-      });
+          unsub();
+        },
+      );
     });
   }
 

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -49,36 +49,55 @@ export default class ProtocolService {
   }
 
   public async registerForMinting(): Promise<string | undefined> {
-    const dataHost = DataHost.instance();
-    const extensionProof = await dataHost.extensionProof();
-    if (extensionProof == null) return;
-    const [length, proof] = extensionProof;
+    const latestProof = await this.latestExtensionProof();
+    console.log(`Latest proof from chain ${latestProof}`);
 
-    const hash = await this.submitMintingExtrinsic(proof);
-    await dataHost.setLastProofLength(length);
-    return hash;
+    const dataHost = DataHost.instance();
+    const extensionProof = await dataHost.extensionProof(latestProof);
+    if (extensionProof == null) return;
+
+    return await this.submitMintingExtrinsic(extensionProof);
+  }
+
+  private async latestExtensionProof(): Promise<string | null> {
+    const fractalId = await this.registeredFractalId();
+    if (fractalId == null) return null;
+
+    // Blue-green strategy handling migration of blockchain storage.
+    try {
+      // Will be long-term code.
+      const dataset =
+        await this.api.query.fractalMinting.idDatasets(this.address(), fractalId);
+      return dataset.toHuman() as string | null;
+    } catch (e) {
+      // TODO(shelbyd): Delete this after rollout of storage change.
+      const dataset =
+        await this.api.query.fractalMinting.idDatasets(fractalId);
+      return dataset.toHuman() as string | null;
+    }
   }
 
   private async submitMintingExtrinsic(proof: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const txn = this.api.tx.fractalMinting.registerForMinting(null, proof);
-      txn.signAndSend(this.signer, (result) => {
-        if (result.status.isFinalized)
-          return resolve(txn.hash.toHuman() as string);
+    console.log(`Submitting proof ${proof}`);
+    const txn = this.api.tx.fractalMinting.registerForMinting(null, proof);
 
-        if (result.dispatchError) {
-          if (result.dispatchError.isModule) {
-            const decoded = this.api.registry.findMetaError(
-              result.dispatchError.asModule,
-            );
-            const { name, section } = decoded;
-            const error = `ProtocolService.registerForMinting error: ${section}.${name}`;
+    return new Promise(async (resolve, reject) => {
+      const unsub = await txn.signAndSend(this.signer, ({ events = [], status }) => {
+        console.log(`Extrinsic status: ${status}`);
+        if (!status.isFinalized) return;
 
-            console.error(error);
+        events.forEach(({ event: { data, method, section } }) => {
+          if (section !== 'system') return;
 
-            reject(error);
+          if (method === 'ExtrinsicSuccess') {
+            resolve(status.asFinalized.toHuman() as string);
           }
-        }
+          if (method === 'ExtrinsicFailed') {
+            reject(data);
+          }
+        });
+
+        unsub();
       });
     });
   }
@@ -96,7 +115,7 @@ export default class ProtocolService {
     const keys = await this.api.query.fractalMinting.accountIds.keys(
       this.address(),
     );
-    if (keys.length === 0) return null;
+    if (keys.length !== 1) return null;
     const fractalId = keys[0].args[1];
     return fractalId as u64;
   }


### PR DESCRIPTION
Also:

* Handle new version of storage
* Use on-chain extension proof
* Explicitly unsubscribe from txn updates

This has potential to fix the memory leak we've encountered, but not likely.