### PR TITLE
Save user email and phone numbers from Megalodon

### DIFF
--- a/src/redux/stores/user/aliases/CredentialsAliases/index.js
+++ b/src/redux/stores/user/aliases/CredentialsAliases/index.js
@@ -4,6 +4,8 @@ import credentialsActions, {
   credentialsTypes,
 } from "@redux/stores/user/reducers/credentials";
 
+import profileActions from "@redux/stores/user/reducers/profile";
+
 import Credential from "@models/Credential";
 import CredentialsCollection from "@models/Credential/CredentialsCollection";
 import VerificationCase from "@models/VerificationCase";
@@ -46,8 +48,11 @@ export const fetchCredentialsAndVerificationCases = () => {
     dispatch(credentialsActions.setCredentials(credentials));
 
     // fetch verification cases
-    const { verification_cases: verificationCases } =
-      await MegalodonService.me();
+    const {
+      verification_cases: verificationCases,
+      phones: phoneNumbers,
+      emails,
+    } = await MegalodonService.me();
 
     const formattedVerificationCases = verificationCases.reduce(
       (
@@ -73,6 +78,9 @@ export const fetchCredentialsAndVerificationCases = () => {
     dispatch(
       credentialsActions.setVerificationCases(formattedVerificationCases),
     );
+
+    dispatch(profileActions.setEmails(emails));
+    dispatch(profileActions.setPhoneNumbers(phoneNumbers));
 
     // Check registration type
     const registrationState = getRegistrationState(getState());

--- a/src/redux/stores/user/index.js
+++ b/src/redux/stores/user/index.js
@@ -27,6 +27,12 @@ import {
 } from "@redux/stores/user/reducers/protocol";
 
 import {
+  reducer as profileReducer,
+  restore as profileRestore,
+  store as profileStore,
+} from "@redux/stores/user/reducers/profile";
+
+import {
   ERROR_DECRYPT_FAILED,
   ERROR_LOCAL_STATE_NOT_FOUND,
   ERROR_SALT_NOT_FOUND,
@@ -103,6 +109,7 @@ export class UserStore {
       credentials: credentialsReducer,
       requests: requestsReducer,
       protocol: protocolReducer,
+      profile: profileReducer,
     });
   }
 
@@ -177,6 +184,7 @@ export class UserStore {
       credentials: await credentialsRestore(deserializedState.credentials),
       requests: await requestsRestore(deserializedState.requests),
       protocol: await protocolRestore(deserializedState.protocol),
+      profile: await profileRestore(deserializedState.profile),
     };
   }
 
@@ -185,6 +193,7 @@ export class UserStore {
       credentials: await credentialsStore(state.credentials),
       requests: await requestsStore(state.requests),
       protocol: await protocolStore(state.protocol),
+      profile: await profileStore(state.profile),
     });
   }
 

--- a/src/redux/stores/user/reducers/profile/index.js
+++ b/src/redux/stores/user/reducers/profile/index.js
@@ -1,0 +1,47 @@
+import mirrorCreator from "mirror-creator";
+import { createActions, handleActions } from "redux-actions";
+
+const types = mirrorCreator(["SET_EMAILS", "SET_PHONE_NUMBERS"]);
+
+export const creators = createActions(
+  types.SET_EMAILS,
+  types.SET_PHONE_NUMBERS,
+);
+
+export const initialState = {
+  emails: "[]",
+  phoneNumbers: "[]",
+};
+
+export const reducer = handleActions(
+  {
+    [types.SET_EMAILS]: (state, { payload: emails }) =>
+      Object.freeze({
+        ...state,
+        emails,
+      }),
+
+    [types.SET_PHONE_NUMBERS]: (state, { payload: phoneNumbers }) =>
+      Object.freeze({
+        ...state,
+        phoneNumbers,
+      }),
+  },
+  initialState,
+);
+
+export async function restore(state = {}) {
+  return {
+    ...initialState,
+    ...state,
+  };
+}
+
+export async function store(state) {
+  return {
+    emails: state.emails,
+    phoneNumbers: state.phoneNumbers,
+  };
+}
+
+export default creators;

--- a/src/redux/stores/user/reducers/profile/selectors.js
+++ b/src/redux/stores/user/reducers/profile/selectors.js
@@ -1,0 +1,11 @@
+import { createSelector } from "reselect";
+
+export const getEmails = createSelector(
+  (state) => state.profile,
+  (profile) => profile.emails,
+);
+
+export const getPhoneNumbers = createSelector(
+  (state) => state.profile,
+  (profile) => profile.phoneNumbers,
+);


### PR DESCRIPTION
Why:

* Users that might have multiple accounts want to know which email/phone
  number they are logged into.

This change addresses the need by:

* Saving the email and phone number when fetching info from Megalodon.

Notes:

* We're still missing design so this PR focus solely on storing the
  information.