### PR TITLE
Remove global state from OptInForm

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,7 @@ module.exports = {
     "^\\@contracts(.*)$": "<rootDir>/src/contracts/$1",
     "^\\@utils(.*)$": "<rootDir>/src/utils/$1",
     "^\\@pluginTypes(.*)$": "<rootDir>/src/types/$1",
+    "^\\@vendor(.*)$": "<rootDir>/src/vendor/$1",
   },
   moduleFileExtensions: [
     "web.js",

--- a/src/popup/components/Protocol/OptInForm/index.tsx
+++ b/src/popup/components/Protocol/OptInForm/index.tsx
@@ -54,7 +54,7 @@ const CTA = styled.div`
   justify-content: center;
 `;
 
-function OptInForm({onOptIn}: {onOptIn: () => void}) {
+function OptInForm({ onOptIn }: { onOptIn: () => void }) {
   return (
     <TopComponent>
       <Container>

--- a/src/popup/components/Protocol/OptInForm/index.tsx
+++ b/src/popup/components/Protocol/OptInForm/index.tsx
@@ -56,13 +56,7 @@ const CTA = styled.div`
   justify-content: center;
 `;
 
-function OptInForm() {
-  const appDispatch = useAppDispatch();
-
-  const onClick = async () => {
-    appDispatch(appActions.setProtocolOptIn(true));
-  };
-
+function OptInForm({onOptIn}: {onOptIn: () => void}) {
   return (
     <TopComponent>
       <Container>
@@ -111,7 +105,7 @@ function OptInForm() {
         <Spacing />
 
         <CTA>
-          <Button onClick={onClick}>Opt In</Button>
+          <Button onClick={onOptIn}>Opt In</Button>
         </CTA>
       </Container>
     </TopComponent>

--- a/src/popup/components/Protocol/OptInForm/index.tsx
+++ b/src/popup/components/Protocol/OptInForm/index.tsx
@@ -2,8 +2,6 @@ import styled from "styled-components";
 
 import Button from "@popup/components/common/Button";
 
-import { useAppDispatch } from "@redux/stores/application/context";
-import appActions from "@redux/stores/application/reducers/app";
 import Icon, { IconNames } from "@popup/components/common/Icon";
 import Text, { TextWeights } from "@popup/components/common/Text";
 import Subtitle, { Subsubtitle } from "@popup/components/common/Subtitle";

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useAppSelector } from "@redux/stores/application/context";
 import { useUserSelector } from "@redux/stores/user/context";
 import { protocolRegistrationTypes } from "@redux/stores/user/reducers/protocol";
 import { getRegistrationState } from "@redux/stores/user/reducers/protocol/selectors";

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -1,31 +1,41 @@
+import { useState, useEffect } from "react";
 import { useAppSelector } from "@redux/stores/application/context";
-import { getProtocolOptIn } from "@redux/stores/application/reducers/app/selectors";
 import { useUserSelector } from "@redux/stores/user/context";
 import { protocolRegistrationTypes } from "@redux/stores/user/reducers/protocol";
 import { getRegistrationState } from "@redux/stores/user/reducers/protocol/selectors";
 
+import { getProtocolOptIn } from "@services/Factory";
 import { ProtocolProvider } from "@services/ProtocolService/";
 
 import SetupScreen from "./SetupScreen";
 import DataScreen from "./DataScreen";
 import OptInForm from "./OptInForm";
 
-function renderProtocol(protocolOptIn: boolean, registrationState: string) {
-  if (!protocolOptIn) return <OptInForm />;
+function ProtocolState() {
+  const [optedIn, setOptedIn] = useState(false);
 
-  if (registrationState === protocolRegistrationTypes.COMPLETED)
-    return <DataScreen />;
+  useEffect(async () => {
+    const optedIn = await getProtocolOptIn().isOptedIn();
+    if (optedIn) setOptedIn(true);
+  });
 
-  return <SetupScreen />;
+  const registrationState = useUserSelector(getRegistrationState);
+
+  if (!optedIn) {
+    return <OptInForm onOptIn={() => setOptedIn(true)} />;
+  }
+
+  if (registrationState !== protocolRegistrationTypes.COMPLETED) {
+    return <SetupScreen />;
+  }
+
+  return <DataScreen />;
 }
 
 function Protocol() {
-  const protocolOptIn = useAppSelector(getProtocolOptIn);
-  const registrationState = useUserSelector(getRegistrationState);
-
   return (
     <ProtocolProvider>
-      {renderProtocol(protocolOptIn, registrationState)}
+      <ProtocolState />
     </ProtocolProvider>
   );
 }

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -14,7 +14,7 @@ import OptInForm from "./OptInForm";
 function ProtocolState() {
   const [optedIn, setOptedIn] = useState(false);
 
-  useEffect(async () => {
+  useAsyncEffect(async () => {
     const optedIn = await getProtocolOptIn().isOptedIn();
     if (optedIn) setOptedIn(true);
   });
@@ -30,6 +30,12 @@ function ProtocolState() {
   }
 
   return <DataScreen />;
+}
+
+function useAsyncEffect(cb: () => Promise<void>) {
+  useEffect(() => {
+    cb();
+  });
 }
 
 function Protocol() {

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -95,7 +95,9 @@ export function getWindowsService() {
 let protocolOptIn: ProtocolOptIn;
 export function getProtocolOptIn() {
   if (protocolOptIn === undefined) {
-    protocolOptIn = new ProtocolOptIn();
+    protocolOptIn = new ProtocolOptIn(getStorageService(), getMaguroService(),
+                                      getProtocolService(), getWindowsService(),
+                                      environment.LIVENESS_JOURNEY_URL);
   }
   return protocolOptIn;
 }

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -100,7 +100,7 @@ export function getProtocolOptIn() {
       getMaguroService(),
       getProtocolService(),
       getWindowsService(),
-      environment.LIVENESS_JOURNEY_URL,
+      environment.PROTOCOL_JOURNEY_URL,
     );
 
     protocolOptIn.postOptInCallbacks.push(async () => {

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -102,6 +102,10 @@ export function getProtocolOptIn() {
       getWindowsService(),
       environment.LIVENESS_JOURNEY_URL,
     );
+
+    protocolOptIn.postOptInCallbacks.push(async () => {
+      await getDataHost().enable();
+    });
   }
   return protocolOptIn;
 }

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -3,11 +3,11 @@ import { ApiPromise, WsProvider } from "@polkadot/api";
 import { DataHost } from "@services/DataHost";
 import { MaguroService } from "@services/MaguroService";
 import { MintingRegistrar } from "@services/MintingRegistrar";
+import { ProtocolOptIn } from "@services/ProtocolOptIn";
 import { ProtocolService } from "@services/ProtocolService";
 import types from "@services/ProtocolService/types";
 import { StorageService } from "@services/StorageService";
 import { WindowsService } from "@services/WindowsService";
-import {ProtocolOptIn} from '@services/ProtocolOptIn';
 
 let storageService: StorageService;
 export function getStorageService() {
@@ -95,9 +95,13 @@ export function getWindowsService() {
 let protocolOptIn: ProtocolOptIn;
 export function getProtocolOptIn() {
   if (protocolOptIn === undefined) {
-    protocolOptIn = new ProtocolOptIn(getStorageService(), getMaguroService(),
-                                      getProtocolService(), getWindowsService(),
-                                      environment.LIVENESS_JOURNEY_URL);
+    protocolOptIn = new ProtocolOptIn(
+      getStorageService(),
+      getMaguroService(),
+      getProtocolService(),
+      getWindowsService(),
+      environment.LIVENESS_JOURNEY_URL,
+    );
   }
   return protocolOptIn;
 }

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -7,6 +7,7 @@ import { ProtocolService } from "@services/ProtocolService";
 import types from "@services/ProtocolService/types";
 import { StorageService } from "@services/StorageService";
 import { WindowsService } from "@services/WindowsService";
+import {ProtocolOptIn} from '@services/ProtocolOptIn';
 
 let storageService: StorageService;
 export function getStorageService() {
@@ -89,4 +90,12 @@ export function getWindowsService() {
     windows = new WindowsService();
   }
   return windows;
+}
+
+let protocolOptIn: ProtocolOptIn;
+export function getProtocolOptIn() {
+  if (protocolOptIn === undefined) {
+    protocolOptIn = new ProtocolOptIn();
+  }
+  return protocolOptIn;
 }

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -13,7 +13,9 @@ export class MaguroService {
   ): Promise<Record<string, string>> {
     if (headers["authorization"]) return headers;
 
-    await appStore.init();
+    if (appStore.getStore() == null) {
+      await appStore.init();
+    }
     const token = getBackendMegalodonSession(appStore.getStore().getState());
 
     headers["authorization"] = `Bearer ${token}`;

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -10,7 +10,7 @@ const HTTP_TIMEOUT = 5 * 60 * 1000; // 5 minutes timeout
 export class MaguroService {
   private async ensureAuthorization(
     headers: Record<string, string>,
-  ): Record<string, string> {
+  ): Promise<Record<string, string>> {
     if (headers["authorization"]) return headers;
 
     await appStore.init();

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -1,18 +1,20 @@
 import Environment from "@environment/index";
-import AppStore from "@redux/stores/application";
+import appStore from "@redux/stores/application";
 import { getBackendMegalodonSession } from "@redux/stores/application/reducers/auth/selectors";
 import CatfishService from "@services/CatfishService";
 import HttpService from "@services/HttpService";
+import { MissingLiveness } from "@services/ProtocolOptIn";
 
 const HTTP_TIMEOUT = 5 * 60 * 1000; // 5 minutes timeout
 
 export class MaguroService {
-  private ensureAuthorization(
+  private async ensureAuthorization(
     headers: Record<string, string>,
   ): Record<string, string> {
     if (headers["authorization"]) return headers;
 
-    const token = getBackendMegalodonSession(AppStore.getStore().getState());
+    await appStore.init();
+    const token = getBackendMegalodonSession(appStore.getStore().getState());
 
     headers["authorization"] = `Bearer ${token}`;
     headers["content-type"] = "application/json";
@@ -26,10 +28,10 @@ export class MaguroService {
     body?: RequestInit["body"],
     headers?: RequestInit["headers"],
   ): Promise<any> {
-    const headersWithAuth = this.ensureAuthorization(
+    const headersWithAuth = await this.ensureAuthorization(
       (headers as Record<string, string>) || {},
     );
-    return this.callApi(route, method, body, headersWithAuth);
+    return await this.callApi(route, method, body, headersWithAuth);
   }
 
   private async callApi(
@@ -49,43 +51,48 @@ export class MaguroService {
     if (!response.ok) {
       // check if megalodon token has expired
       if (response.status === 401) {
-        return CatfishService.refreshResourceServerToken().then(
-          async (token) => {
-            const response = await HttpService.call(
-              `${Environment.MAGURO_URL}/${route}`,
-              method,
-              body,
-              {
-                ...headers,
-                authorization: `Bearer ${token}`,
-              },
-            );
-
-            if (!response.ok) {
-              throw new Error(response.statusText);
-            }
-
-            return response.json();
+        const token = await CatfishService.refreshResourceServerToken();
+        const response = await HttpService.call(
+          `${Environment.MAGURO_URL}/${route}`,
+          method,
+          body,
+          {
+            ...headers,
+            authorization: `Bearer ${token}`,
           },
         );
+
+        if (!response.ok) {
+          throw new Error(response.statusText);
+        }
+
+        return response.json();
       }
 
-      throw new Error(response.statusText);
+      throw await response.json();
     }
 
-    return response.json();
+    return await response.json();
   }
 
   public getCredentials() {
     return this.callAuthorizedApi("credentials", "GET", null);
   }
 
-  public registerIdentity(address: string) {
-    return this.callAuthorizedApi(
-      "protocol/register_identity",
-      "POST",
-      JSON.stringify({ linked_address: address }),
-    );
+  public async registerIdentity(address: string) {
+    try {
+      return await this.callAuthorizedApi(
+        "protocol/register_identity",
+        "POST",
+        JSON.stringify({ linked_address: address }),
+      );
+    } catch (e) {
+      if (e.error === "missing_liveness") {
+        throw new MissingLiveness();
+      } else {
+        throw e;
+      }
+    }
   }
 
   public getConfig() {

--- a/src/services/ProtocolOptIn.ts
+++ b/src/services/ProtocolOptIn.ts
@@ -9,7 +9,7 @@ export class ProtocolOptIn {
   constructor(
       private readonly storage: Storage,
       private readonly maguro: MaguroService,
-      private readonly protocol: ProtocolService,
+      private readonly protocol: Promise<ProtocolService>,
       private readonly windows: WindowsService,
       private readonly livenessUrl: string,
   ) {}
@@ -33,8 +33,8 @@ export class ProtocolOptIn {
   private async tryRegisterIdentity(onMissingLiveness?: () => Promise<void>) {
     const mnemonic = await this.storage.getItem('opt-in/mnemonic');
     try {
-      await this.maguro.registerIdentity(
-          this.protocol.addressForMnemonic(mnemonic));
+      const address = (await this.protocol).addressForMnemonic(mnemonic!);
+      await this.maguro.registerIdentity(address);
       await this.storage.setItem('opt-in/liveness-complete', 'true');
     } catch (e) {
       if (!(e instanceof MissingLiveness)) {

--- a/src/services/ProtocolOptIn.ts
+++ b/src/services/ProtocolOptIn.ts
@@ -1,41 +1,44 @@
-import {MaguroService} from '@services/MaguroService';
-import {ProtocolService} from '@services/ProtocolService';
-import {WindowsService} from '@services/WindowsService';
-import {Storage} from '@utils/StorageArray';
+import { MaguroService } from "@services/MaguroService";
+import { ProtocolService } from "@services/ProtocolService";
+import { WindowsService } from "@services/WindowsService";
+import { Storage } from "@utils/StorageArray";
 
 export class MissingLiveness extends Error {}
 
 export class ProtocolOptIn {
   constructor(
-      private readonly storage: Storage,
-      private readonly maguro: MaguroService,
-      private readonly protocol: Promise<ProtocolService>,
-      private readonly windows: WindowsService,
-      private readonly livenessUrl: string,
+    private readonly storage: Storage,
+    private readonly maguro: MaguroService,
+    private readonly protocol: Promise<ProtocolService>,
+    private readonly windows: WindowsService,
+    private readonly livenessUrl: string,
   ) {}
 
-  async isOptedIn() { return await this.storage.hasItem('opt-in/mnemonic'); }
+  async isOptedIn() {
+    return await this.storage.hasItem("opt-in/mnemonic");
+  }
 
   async hasCompletedLiveness() {
-    return this.storage.hasItem('opt-in/liveness-complete');
+    return this.storage.hasItem("opt-in/liveness-complete");
   }
 
   async optIn(mnemonic: string) {
-    await this.storage.setItem('opt-in/mnemonic', mnemonic);
+    await this.storage.setItem("opt-in/mnemonic", mnemonic);
     await this.tryRegisterIdentity();
   }
 
   async postOptInLiveness() {
-    await this.tryRegisterIdentity(
-        async () => { await this.windows.openTab(this.livenessUrl); });
+    await this.tryRegisterIdentity(async () => {
+      await this.windows.openTab(this.livenessUrl);
+    });
   }
 
   private async tryRegisterIdentity(onMissingLiveness?: () => Promise<void>) {
-    const mnemonic = await this.storage.getItem('opt-in/mnemonic');
+    const mnemonic = await this.storage.getItem("opt-in/mnemonic");
     try {
       const address = (await this.protocol).addressForMnemonic(mnemonic!);
       await this.maguro.registerIdentity(address);
-      await this.storage.setItem('opt-in/liveness-complete', 'true');
+      await this.storage.setItem("opt-in/liveness-complete", "true");
     } catch (e) {
       if (!(e instanceof MissingLiveness)) {
         throw e;

--- a/src/services/ProtocolOptIn.ts
+++ b/src/services/ProtocolOptIn.ts
@@ -21,7 +21,7 @@ export class ProtocolOptIn {
   }
 
   async hasCompletedLiveness() {
-    return this.storage.hasItem("opt-in/liveness-complete");
+    return (await this.protocol).isIdentityRegistered();
   }
 
   async optIn(mnemonic: string) {
@@ -43,7 +43,6 @@ export class ProtocolOptIn {
     try {
       const address = (await this.protocol).addressForMnemonic(mnemonic!);
       await this.maguro.registerIdentity(address);
-      await this.storage.setItem("opt-in/liveness-complete", "true");
     } catch (e) {
       if (!(e instanceof MissingLiveness)) {
         throw e;

--- a/src/services/ProtocolOptIn.ts
+++ b/src/services/ProtocolOptIn.ts
@@ -1,0 +1,48 @@
+import {MaguroService} from '@services/MaguroService';
+import {ProtocolService} from '@services/ProtocolService';
+import {WindowsService} from '@services/WindowsService';
+import {Storage} from '@utils/StorageArray';
+
+export class MissingLiveness extends Error {}
+
+export class ProtocolOptIn {
+  constructor(
+      private readonly storage: Storage,
+      private readonly maguro: MaguroService,
+      private readonly protocol: ProtocolService,
+      private readonly windows: WindowsService,
+      private readonly livenessUrl: string,
+  ) {}
+
+  async isOptedIn() { return await this.storage.hasItem('opt-in/mnemonic'); }
+
+  async hasCompletedLiveness() {
+    return this.storage.hasItem('opt-in/liveness-complete');
+  }
+
+  async optIn(mnemonic: string) {
+    await this.storage.setItem('opt-in/mnemonic', mnemonic);
+    await this.tryRegisterIdentity();
+  }
+
+  async postOptInLiveness() {
+    await this.tryRegisterIdentity(
+        async () => { await this.windows.openTab(this.livenessUrl); });
+  }
+
+  private async tryRegisterIdentity(onMissingLiveness?: () => Promise<void>) {
+    const mnemonic = await this.storage.getItem('opt-in/mnemonic');
+    try {
+      await this.maguro.registerIdentity(
+          this.protocol.addressForMnemonic(mnemonic));
+      await this.storage.setItem('opt-in/liveness-complete', 'true');
+    } catch (e) {
+      if (!(e instanceof MissingLiveness)) {
+        throw e;
+      }
+      if (onMissingLiveness != null) {
+        await onMissingLiveness();
+      }
+    }
+  }
+}

--- a/src/services/ProtocolOptIn.ts
+++ b/src/services/ProtocolOptIn.ts
@@ -6,6 +6,8 @@ import { Storage } from "@utils/StorageArray";
 export class MissingLiveness extends Error {}
 
 export class ProtocolOptIn {
+  public postOptInCallbacks: Array<() => Promise<void>> = [];
+
   constructor(
     private readonly storage: Storage,
     private readonly maguro: MaguroService,
@@ -24,6 +26,9 @@ export class ProtocolOptIn {
 
   async optIn(mnemonic: string) {
     await this.storage.setItem("opt-in/mnemonic", mnemonic);
+    for (const cb of this.postOptInCallbacks) {
+      await cb();
+    }
     await this.tryRegisterIdentity();
   }
 

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -129,6 +129,12 @@ export class ProtocolService {
     return data;
   }
 
+  public addressForMnemonic(mnemonic: string): string {
+    const keyring = new Keyring({type : "sr25519"});
+    const signer = keyring.addFromUri(mnemonic);
+    return signer.address;
+  }
+
   async saveSigner(storage: Storage) {
     await storage.setItem(
       "protocol/signer",

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -130,7 +130,7 @@ export class ProtocolService {
   }
 
   public addressForMnemonic(mnemonic: string): string {
-    const keyring = new Keyring({type : "sr25519"});
+    const keyring = new Keyring({ type: "sr25519" });
     const signer = keyring.addFromUri(mnemonic);
     return signer.address;
   }

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -114,7 +114,7 @@ export class ProtocolService {
     console.log("Identity successfully registered");
   }
 
-  private async isIdentityRegistered(): Promise<boolean> {
+  public async isIdentityRegistered(): Promise<boolean> {
     const fractalId = await this.registeredFractalId();
     return fractalId != null;
   }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,13 +6,3 @@ import "@testing-library/jest-dom";
 
 // mock the Chrome API
 Object.assign(global, require("jest-chrome"));
-
-// remove console.{log,error,warn,info,debug} when testing
-global.console = {
-  ...console,
-  log: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-  info: jest.fn(),
-  debug: jest.fn(),
-};

--- a/src/tests/unit/ProtocolOptIn.test.ts
+++ b/src/tests/unit/ProtocolOptIn.test.ts
@@ -1,0 +1,154 @@
+import {MissingLiveness, ProtocolOptIn} from '@services/ProtocolOptIn';
+
+class MockStorage {
+  private items = new Map();
+
+  setItem(key: string, value: string) { this.items.set(key, value); }
+  getItem(key: string) { return this.items.get(key); }
+  hasItem(key: string) { return this.items.has(key); }
+}
+
+describe('ProtocolOptIn', () => {
+  function createSpyObj(props: string[]) {
+    const obj = {};
+    for (const prop of props) {
+      obj[prop] = jest.fn().mockName(prop);
+    }
+    return obj;
+  }
+
+  function graph(deps?: any) {
+    deps = deps || {};
+
+    const storage = deps.storage || new MockStorage();
+
+    const maguro = deps.maguro || createSpyObj([ 'registerIdentity' ]);
+    maguro.missingLiveness = () => {
+      maguro.registerIdentity.mockImplementation(
+          () => { throw new MissingLiveness(); });
+    };
+    maguro.hasLiveness =
+        () => { maguro.registerIdentity.mockImplementation(() => {}); };
+
+    const protocol = deps.protocol || createSpyObj([ 'addressForMnemonic' ]);
+
+    const windows = deps.windows || createSpyObj([ 'openTab' ]);
+
+    const livenessUrl = deps.livenessUrl || 'http://fractal-liveness.com';
+
+    protocol.addressForMnemonic.mockImplementation(mne =>
+                                                       `${mne}/some address`);
+
+    const optIn =
+        new ProtocolOptIn(storage, maguro, protocol, windows, livenessUrl);
+    return {storage, optIn, maguro, windows, livenessUrl};
+  }
+
+  it('starts as not isOptedIn', async () => {
+    const {optIn} = graph();
+
+    expect(await optIn.isOptedIn()).toEqual(false);
+  });
+
+  describe('optIn', () => {
+    it('registers identity in Maguro', async () => {
+      const {maguro, optIn} = graph();
+
+      await optIn.optIn('some mnemonic');
+
+      expect(maguro.registerIdentity)
+          .toHaveBeenCalledWith('some mnemonic/some address');
+    });
+
+    it('isOptedIn is true', async () => {
+      const {optIn} = graph();
+
+      await optIn.optIn('some mnemonic');
+
+      expect(await optIn.isOptedIn()).toEqual(true);
+    });
+
+    it('has liveness', async () => {
+      const {optIn} = graph();
+
+      await optIn.optIn('some mnemonic');
+
+      expect(await optIn.hasCompletedLiveness()).toEqual(true);
+    });
+
+    it('has liveness on new instance', async () => {
+      const {storage, optIn} = graph();
+      await optIn.optIn('some mnemonic');
+
+      const {optIn : newOptIn} = graph({storage});
+
+      expect(await newOptIn.hasCompletedLiveness()).toEqual(true);
+    });
+  });
+
+  it('loads isOptedIn from storage', async () => {
+    const {storage, optIn} = graph();
+
+    await optIn.optIn('some mnemonic');
+
+    const {optIn : newOptIn} = graph({storage});
+
+    expect(await newOptIn.isOptedIn()).toEqual(true);
+  });
+
+  describe('missing liveness', () => {
+    it('does not have liveness', async () => {
+      const {maguro, optIn} = graph();
+      maguro.missingLiveness();
+
+      await optIn.optIn('some mnemonic');
+
+      expect(await optIn.hasCompletedLiveness()).toEqual(false);
+    });
+
+    it('does not have liveness on new instance', async () => {
+      const {storage, maguro, optIn} = graph();
+      maguro.missingLiveness();
+
+      await optIn.optIn('some mnemonic');
+
+      const {optIn : newOptIn} = graph({storage});
+
+      expect(await newOptIn.hasCompletedLiveness()).toEqual(false);
+    });
+  });
+
+  describe('postOptInLiveness', () => {
+    it('tries to registerIdentity', async () => {
+      const {maguro, optIn} = graph();
+      maguro.missingLiveness();
+      await optIn.optIn('some mnemonic');
+
+      await optIn.postOptInLiveness();
+
+      expect(maguro.registerIdentity)
+          .toHaveBeenCalledWith('some mnemonic/some address');
+    });
+
+    it('sets liveness on instances', async () => {
+      const {storage, maguro, optIn} = graph();
+      maguro.missingLiveness();
+      await optIn.optIn('some mnemonic');
+
+      maguro.hasLiveness();
+      await optIn.postOptInLiveness();
+
+      const {optIn : newOptIn} = graph({storage});
+      expect(await newOptIn.hasCompletedLiveness()).toEqual(true);
+    });
+
+    it('opens liveness journey if no liveness', async () => {
+      const {maguro, optIn, windows, livenessUrl} = graph();
+      maguro.missingLiveness();
+      await optIn.optIn('some mnemonic');
+      await optIn.postOptInLiveness();
+
+      expect(windows.openTab).toHaveBeenCalledWith(livenessUrl);
+    });
+  });
+});

--- a/src/utils/StorageArray.ts
+++ b/src/utils/StorageArray.ts
@@ -1,6 +1,7 @@
 export interface Storage {
   setItem(key: string, value: string): Promise<void>;
   getItem(key: string): Promise<string | undefined>;
+  hasItem(key: string): Promise<boolean>;
   removeItem(key: string): Promise<void>;
 }
 
@@ -22,6 +23,10 @@ class PrefixStorage {
     return await this.base.getItem(this.key(key));
   }
 
+  async hasItem(key: string): Promise<boolean> {
+    return await this.base.hasItem(this.key(key));
+  }
+
   async removeItem(key: string) {
     await this.base.removeItem(this.key(key));
   }
@@ -38,6 +43,10 @@ class StringifyStorage {
     const value = await this.base.getItem(key);
     if (value == null) return null;
     return JSON.parse(value);
+  }
+
+  async hasItem(key: string): Promise<boolean> {
+    return this.base.hasItem(key);
   }
 
   async removeItem(key: string) {


### PR DESCRIPTION
This is the first in a few PRs that will be migrating each part of the opt-in flow from updating global state to calling callbacks into one rendering function that manages side effects.