### PR TITLE
Show credentials on Credentials tab

### DIFF
--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -14,7 +14,7 @@ const MAGURO_URL =
   "https://maguro.staging.sandbox.fractal.id";
 const LIVENESS_JOURNEY_URL =
   process.env.REACT_APP_LIVENESS_JOURNEY_URL ||
-  "https://staging.sandbox.fractal.id/kyc/liveness";
+  "https://staging.sandbox.fractal.id/authorize?client_id=8spOoo1zjZQVMqO3qzPlf2B4OGhFyN0eIbYFcVgGN3M&redirect_uri=https%3A%2F%2Fstaging.sandbox.fractal.id&response_type=code&scope=contact%3Aread%20verification.plus%3Aread%20verification.plus.details%3Aread%20verification.liveness%3Aread%20verification.liveness.details%3Aread%20verification.wallet%3Aread%20verification.wallet.details%3Aread";
 const PROTOCOL_JOURNEY_URL =
   process.env.REACT_APP_PROTOCOL_JOURNEY_URL ||
   "https://staging.sandbox.fractal.id/authorize?client_id=7bSJYDc0ywg9ml377DIk45-tjUxdHgVt-MJC6So56Ho&redirect_uri=https%3A%2F%2Fstaging.sandbox.fractal.id%2Fprotocol&response_type=code&scope=verification.protocol%3Aread";

--- a/src/models/Credential/CredentialsCollection.ts
+++ b/src/models/Credential/CredentialsCollection.ts
@@ -13,4 +13,21 @@ export default class CredentialsCollection extends Collection<ICredential> {
 
     return new CredentialsCollection(...elements);
   }
+
+  static fromRpcList(userCredentials: ICredential[]) {
+    const credentials = userCredentials.reduce((memo: CredentialsCollection, credential: any) => {
+      memo.push(
+        new Credential(
+          { ...credential.data },
+          `${credential.verification_case_id}:${credential.level}`,
+          credential.level,
+          credential.verification_case_id,
+          new Date(credential.created_at).getTime(),
+        ),
+      );
+
+      return memo;
+    }, new CredentialsCollection());
+    return credentials;
+  }
 }

--- a/src/models/Credential/CredentialsCollection.ts
+++ b/src/models/Credential/CredentialsCollection.ts
@@ -15,19 +15,26 @@ export default class CredentialsCollection extends Collection<ICredential> {
   }
 
   static fromRpcList(userCredentials: ICredential[]) {
-    const credentials = userCredentials.reduce((memo: CredentialsCollection, credential: any) => {
-      memo.push(
-        new Credential(
-          { ...credential.data },
-          `${credential.verification_case_id}:${credential.level}`,
-          credential.level,
-          credential.verification_case_id,
-          new Date(credential.created_at).getTime(),
-        ),
-      );
+    const credentials = userCredentials.reduce(
+      (memo: CredentialsCollection, credential: any) => {
+        memo.push(
+          new Credential(
+            { ...credential.data },
+            `${credential.verification_case_id}:${credential.level}`,
+            credential.level,
+            credential.verification_case_id,
+            new Date(credential.created_at).getTime(),
+          ),
+        );
 
-      return memo;
-    }, new CredentialsCollection());
+        return memo;
+      },
+      new CredentialsCollection(),
+    );
     return credentials;
+  }
+
+  static empty() {
+    return new CredentialsCollection();
   }
 }

--- a/src/models/VerificationCase/VerificationCasesCollection.ts
+++ b/src/models/VerificationCase/VerificationCasesCollection.ts
@@ -22,7 +22,7 @@ export default class VerificationCasesCollection extends Collection<IVerificatio
     return cases.reduce(
       (
         memo,
-        { id, client_id, level, status, credential, journey_completed }
+        { id, client_id, level, status, credential, journey_completed },
       ) => {
         let vcStatus = VerificationCase.getStatus({
           id,

--- a/src/models/VerificationCase/VerificationCasesCollection.ts
+++ b/src/models/VerificationCase/VerificationCasesCollection.ts
@@ -2,6 +2,7 @@ import { IVerificationCase } from "@pluginTypes/index";
 
 import { KYCTypes } from "@trustfractal/sdk";
 
+import { ICredential } from "@pluginTypes/index";
 import Collection from "@models/Base/BaseCollection";
 import VerificationCase from "@models/VerificationCase";
 import VerificationCaseStatus from "@models/VerificationCase/status";
@@ -15,6 +16,29 @@ export default class VerificationCasesCollection extends Collection<IVerificatio
     );
 
     return new VerificationCasesCollection(...elements);
+  }
+
+  static fromRpcList(cases: any[], credentials: ICredential[]) {
+    return cases.reduce(
+      (
+        memo,
+        { id, client_id, level, status, credential, journey_completed }
+      ) => {
+        let vcStatus = VerificationCase.getStatus({
+          id,
+          level,
+          status,
+          credential,
+          journey_completed,
+          credentials,
+        });
+
+        memo.push(new VerificationCase(id, client_id, level, vcStatus));
+
+        return memo;
+      },
+      new VerificationCasesCollection(),
+    );
   }
 
   public filterProtocolVerificationCases() {

--- a/src/popup/components/Credentials/index.tsx
+++ b/src/popup/components/Credentials/index.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 
+import Loading from "@popup/components/Loading";
 import { useLoadedState, useObservedState } from "@utils/ReactHooks";
 import { isSetup } from "@redux/stores/application/reducers/app/selectors";
 import CredentialComponent from "@popup/components/common/Credential";
@@ -68,7 +69,7 @@ function Credentials() {
     () => getFractalAccountConnector().connectedAccount$,
   );
 
-  if (!connectedAccount.hasValue) return <></>;
+  if (!connectedAccount.hasValue) return <Loading />;
 
   if (setup !== connectedAccount.value) {
     dispatch(appActions.setSetup(connectedAccount.value));
@@ -81,7 +82,7 @@ function Credentials() {
     );
   }
 
-  if (!credentialsLoading.isLoaded) return <></>;
+  if (!credentialsLoading.isLoaded) return <Loading />;
   const [credentials, upcomingCredentials] = credentialsLoading.value;
 
   if (credentials.length === 0 && upcomingCredentials.length === 0)

--- a/src/popup/components/Credentials/index.tsx
+++ b/src/popup/components/Credentials/index.tsx
@@ -67,7 +67,7 @@ function Credentials() {
         verificationCases.filterPendingOrContactedOrIssuingSupportedVerificationCases(),
       ];
     },
-    onValue: ([credentials,]) => {
+    onValue: ([credentials]) => {
       credentialsSubject.next(credentials);
     },
     serialize: ([credentials, upcomingCredentials]) => {

--- a/src/popup/components/Credentials/index.tsx
+++ b/src/popup/components/Credentials/index.tsx
@@ -57,7 +57,6 @@ function Credentials() {
       const { credentials: rpcCredentials } =
         await getMaguroService().getCredentials();
       const credentials = CredentialsCollection.fromRpcList(rpcCredentials);
-      credentialsSubject.next(credentials);
       const { verification_cases: cases } = await getMegalodonService().me();
       const verificationCases = VerificationCasesCollection.fromRpcList(
         cases,
@@ -67,6 +66,9 @@ function Credentials() {
         credentials,
         verificationCases.filterPendingOrContactedOrIssuingSupportedVerificationCases(),
       ];
+    },
+    onValue: ([credentials,]) => {
+      credentialsSubject.next(credentials);
     },
     serialize: ([credentials, upcomingCredentials]) => {
       return JSON.stringify([

--- a/src/popup/components/Loading/index.tsx
+++ b/src/popup/components/Loading/index.tsx
@@ -1,4 +1,7 @@
 import styled from "styled-components";
+import { useEffect } from "react";
+
+import environment from "@environment/index";
 
 import Spinner from "../common/Spinner";
 import Text, { TextHeights, TextSizes } from "../common/Text";
@@ -28,6 +31,14 @@ const SpinnerContainer = styled.div`
 `;
 
 function Loading() {
+  useEffect(() => {
+    const start = window.performance.now();
+    return () => {
+      if (!environment.IS_DEV) return;
+      console.info('Showed loading for', window.performance.now() - start, 'ms');
+    };
+  }, []);
+
   return (
     <RootContainer>
       <Logo />

--- a/src/popup/components/Loading/index.tsx
+++ b/src/popup/components/Loading/index.tsx
@@ -35,7 +35,11 @@ function Loading() {
     const start = window.performance.now();
     return () => {
       if (!environment.IS_DEV) return;
-      console.info('Showed loading for', window.performance.now() - start, 'ms');
+      console.info(
+        "Showed loading for",
+        window.performance.now() - start,
+        "ms",
+      );
     };
   }, []);
 

--- a/src/popup/components/Loading/index.tsx
+++ b/src/popup/components/Loading/index.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 
-import TopComponent from "@popup/components/common/TopComponent";
 import Spinner from "../common/Spinner";
 import Text, { TextHeights, TextSizes } from "../common/Text";
 import Logo from "../common/Logo";
@@ -30,19 +29,17 @@ const SpinnerContainer = styled.div`
 
 function Loading() {
   return (
-    <TopComponent>
-      <RootContainer>
-        <Logo />
-        <LabelContainer>
-          <SpinnerContainer>
-            <Spinner alternative />
-          </SpinnerContainer>
-          <Text size={TextSizes.LARGE} height={TextHeights.LARGE}>
-            Loading...
-          </Text>
-        </LabelContainer>
-      </RootContainer>
-    </TopComponent>
+    <RootContainer>
+      <Logo />
+      <LabelContainer>
+        <SpinnerContainer>
+          <Spinner alternative />
+        </SpinnerContainer>
+        <Text size={TextSizes.LARGE} height={TextHeights.LARGE}>
+          Loading...
+        </Text>
+      </LabelContainer>
+    </RootContainer>
   );
 }
 

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -4,6 +4,7 @@ import { useLoadedState } from "@utils/ReactHooks";
 import { getProtocolOptIn } from "@services/Factory";
 import TopComponent from "@popup/components/common/TopComponent";
 
+import Loading from "@popup/components/Loading";
 import DataScreen from "./DataScreen";
 import { OptInForm } from "./OptInForm";
 import MnemonicPicker from "./MnemonicPicker";
@@ -52,7 +53,7 @@ function ProtocolState() {
     return pageOverride;
   }
 
-  if (!serviceOptedIn.isLoaded) return null;
+  if (!serviceOptedIn.isLoaded) return <Loading />;
   const optedIn = manualOptIn || serviceOptedIn.value;
   if (!optedIn) {
     return <OptInForm onOptIn={() => setManualOptIn(true)} />;
@@ -61,7 +62,7 @@ function ProtocolState() {
     return <MnemonicPicker onMnemonicPicked={optInWithMnemonic} />;
   }
 
-  if (!completedLiveness.isLoaded) return null;
+  if (!completedLiveness.isLoaded) return <Loading />;
   if (!completedLiveness.value) {
     return <NoLiveness onClick={doLiveness} />;
   }

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-import { useCachedState } from "@utils/ReactHooks";
-import { getValueCache, getProtocolOptIn } from "@services/Factory";
+import { useLoadedState } from "@utils/ReactHooks";
+import { getProtocolOptIn } from "@services/Factory";
 import TopComponent from "@popup/components/common/TopComponent";
 
 import Loading from "@popup/components/Loading";
@@ -15,16 +15,10 @@ function ProtocolState() {
   const [pageOverride, setPageOverride] = useState<JSX.Element | null>(null);
 
   const [manualOptIn, setManualOptIn] = useState(false);
-  const serviceOptedIn = useCachedState({
-    cache: getValueCache(),
-    key: 'service-opted-in',
-    loader: () => getProtocolOptIn().isOptedIn(),
-  });
-  const completedLiveness = useCachedState({
-    cache: getValueCache(),
-    key: 'completed-liveness',
-    loader: () => getProtocolOptIn().hasCompletedLiveness(),
-  });
+  const serviceOptedIn = useLoadedState(() => getProtocolOptIn().isOptedIn());
+  const completedLiveness = useLoadedState(() =>
+    getProtocolOptIn().hasCompletedLiveness(),
+  );
 
   const optInWithMnemonic = async (mnemonic: string) => {
     try {

--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-import { useLoadedState } from "@utils/ReactHooks";
-import { getProtocolOptIn } from "@services/Factory";
+import { useCachedState } from "@utils/ReactHooks";
+import { getValueCache, getProtocolOptIn } from "@services/Factory";
 import TopComponent from "@popup/components/common/TopComponent";
 
 import Loading from "@popup/components/Loading";
@@ -15,10 +15,16 @@ function ProtocolState() {
   const [pageOverride, setPageOverride] = useState<JSX.Element | null>(null);
 
   const [manualOptIn, setManualOptIn] = useState(false);
-  const serviceOptedIn = useLoadedState(() => getProtocolOptIn().isOptedIn());
-  const completedLiveness = useLoadedState(() =>
-    getProtocolOptIn().hasCompletedLiveness(),
-  );
+  const serviceOptedIn = useCachedState({
+    cache: getValueCache(),
+    key: 'service-opted-in',
+    loader: () => getProtocolOptIn().isOptedIn(),
+  });
+  const completedLiveness = useCachedState({
+    cache: getValueCache(),
+    key: 'completed-liveness',
+    loader: () => getProtocolOptIn().hasCompletedLiveness(),
+  });
 
   const optInWithMnemonic = async (mnemonic: string) => {
     try {

--- a/src/popup/components/common/NavBar/index.tsx
+++ b/src/popup/components/common/NavBar/index.tsx
@@ -111,15 +111,12 @@ const BalanceReservedLabel = styled.span`
 
 function DropdownMenu() {
   const history = useHistory();
-  const appDispatch = useAppDispatch();
   const credentials = useObservedState(
     () => credentialsSubject,
   ).unwrapOrDefault(CredentialsCollection.empty());
 
   const onClickExport = async () =>
     exportFile(credentials.serialize(), "fractal_wallet.backup");
-
-  const onClickRefresh = () => appDispatch(appActions.refresh());
 
   const onClickAbout = () => history.push(RoutesPaths.ABOUT);
 
@@ -143,11 +140,6 @@ function DropdownMenu() {
         getUserAlerts().send("Mnemonic copied to clipboard!");
       },
       disabled: !mnemonic.isLoaded || mnemonic.value == null,
-    },
-    {
-      label: "Refresh",
-      icon: IconNames.REFRESH,
-      onClick: onClickRefresh,
     },
     {
       label: "About",

--- a/src/popup/components/common/NavBar/index.tsx
+++ b/src/popup/components/common/NavBar/index.tsx
@@ -5,9 +5,7 @@ import type { AccountData, Balance } from "@polkadot/types/interfaces";
 
 import { useAppDispatch } from "@redux/stores/application/context";
 import appActions from "@redux/stores/application/reducers/app";
-import { useUserSelector } from "@redux/stores/user/context";
 
-import { getCredentials } from "@redux/stores/user/reducers/credentials/selectors";
 import Logo, { LogoSizes } from "@popup/components/common/Logo";
 import Text, {
   TextHeights,
@@ -16,9 +14,10 @@ import Text, {
 } from "@popup/components/common/Text";
 import { IconNames } from "@popup/components/common/Icon";
 import Menu from "@popup/components/common/Menu";
+import CredentialsCollection from "@models/Credential/CredentialsCollection";
 
 import { exportFile } from "@utils/FileUtils";
-import { useLoadedState } from "@utils/ReactHooks";
+import { useLoadedState, useObservedState } from "@utils/ReactHooks";
 
 import RoutesPaths from "@popup/routes/paths";
 import {
@@ -28,6 +27,7 @@ import {
   getProtocolOptIn,
   getUserAlerts,
 } from "@services/Factory";
+import { credentialsSubject } from "@services/Observables";
 
 import environment from "@environment/index";
 
@@ -112,7 +112,9 @@ const BalanceReservedLabel = styled.span`
 function DropdownMenu() {
   const history = useHistory();
   const appDispatch = useAppDispatch();
-  const credentials = useUserSelector(getCredentials);
+  const credentials = useObservedState(
+    () => credentialsSubject,
+  ).unwrapOrDefault(CredentialsCollection.empty());
 
   const onClickExport = async () =>
     exportFile(credentials.serialize(), "fractal_wallet.backup");

--- a/src/popup/containers/LoadingScreen/index.tsx
+++ b/src/popup/containers/LoadingScreen/index.tsx
@@ -1,7 +1,12 @@
 import Loading from "@popup/components/Loading";
+import TopComponent from "@popup/components/common/TopComponent";
 
 function LoadingScreen() {
-  return <Loading />;
+  return (
+    <TopComponent>
+      <Loading />
+    </TopComponent>
+  );
 }
 
 export default LoadingScreen;

--- a/src/redux/stores/application/aliases/AppAliases/index.js
+++ b/src/redux/stores/application/aliases/AppAliases/index.js
@@ -9,7 +9,6 @@ import metadataActions, {
 } from "@redux/stores/application/reducers/metadata";
 
 import UserStore from "@redux/stores/user";
-import credentialsActions from "@redux/stores/user/reducers/credentials";
 
 import CredentialsPolling from "@models/Polling/CredentialsPolling";
 import { getMaguroService, getWindowsService } from "@services/Factory";
@@ -98,20 +97,10 @@ const fetchConfig = () => {
   };
 };
 
-const refresh = () => {
-  return async () => {
-    AppStore.getStore().dispatch(appActions.fetchConfig());
-    UserStore.getStore().dispatch(
-      credentialsActions.fetchCredentialsAndVerificationCases(),
-    );
-  };
-};
-
 const Aliases = {
   [appTypes.STARTUP]: startup,
   [appTypes.SET_POPUP_SIZE]: setPopupSize,
   [appTypes.FETCH_CONFIG]: fetchConfig,
-  [appTypes.REFRESH]: refresh,
 };
 
 export default Aliases;

--- a/src/redux/stores/application/reducers/app/index.js
+++ b/src/redux/stores/application/reducers/app/index.js
@@ -19,7 +19,6 @@ const types = mirrorCreator([
   "SET_NETWORK",
   "SET_LIVENESS_CHECK_ENABLED",
   "FETCH_CONFIG",
-  "REFRESH",
 ]);
 
 const creators = createActions(
@@ -35,7 +34,6 @@ const creators = createActions(
   types.SET_NETWORK,
   types.SET_LIVENESS_CHECK_ENABLED,
   types.FETCH_CONFIG,
-  types.REFRESH,
 );
 
 const initialState = {

--- a/src/redux/stores/user/reducers/credentials/index.js
+++ b/src/redux/stores/user/reducers/credentials/index.js
@@ -20,11 +20,13 @@ const initialState = {
 
 export const reducer = handleActions(
   {
-    [types.SET_CREDENTIALS]: (state, { payload: credentials }) =>
-      Object.freeze({
+    [types.SET_CREDENTIALS]: (state, { payload: credentials }) => {
+      console.log("setCredentials");
+      return Object.freeze({
         ...state,
         credentials: credentials.serialize(),
-      }),
+      });
+    },
     [types.SET_VERIFICATION_CASES]: (state, { payload: verificationCases }) =>
       Object.freeze({
         ...state,

--- a/src/redux/stores/user/reducers/credentials/index.js
+++ b/src/redux/stores/user/reducers/credentials/index.js
@@ -20,13 +20,11 @@ const initialState = {
 
 export const reducer = handleActions(
   {
-    [types.SET_CREDENTIALS]: (state, { payload: credentials }) => {
-      console.log("setCredentials");
-      return Object.freeze({
+    [types.SET_CREDENTIALS]: (state, { payload: credentials }) =>
+      Object.freeze({
         ...state,
         credentials: credentials.serialize(),
-      });
-    },
+      }),
     [types.SET_VERIFICATION_CASES]: (state, { payload: verificationCases }) =>
       Object.freeze({
         ...state,

--- a/src/services/Factory.ts
+++ b/src/services/Factory.ts
@@ -14,6 +14,7 @@ import { RecoverMnemonicService } from "@services/RecoverMnemonicService";
 import { UserAlerts } from "@popup/Alerts";
 import { MultiContext, AggregateMultiContext } from "@utils/MultiContext";
 import { FractalAccountConnector } from "@services/FractalAccount";
+import { ValueCache } from "@utils/ReactHooks";
 
 let storageService: StorageService;
 export function getStorageService() {
@@ -169,4 +170,12 @@ export function getMultiContext() {
     multiContext = new AggregateMultiContext([getFractalAccountConnector()]);
   }
   return multiContext;
+}
+
+let valueCache: ValueCache;
+export function getValueCache() {
+  if (valueCache == null) {
+    valueCache = new ValueCache(getStorageService());
+  }
+  return valueCache;
 }

--- a/src/services/Observables.ts
+++ b/src/services/Observables.ts
@@ -1,0 +1,5 @@
+import { ReplaySubject } from "rxjs";
+
+import CredentialsCollection from "@models/Credential/CredentialsCollection";
+
+export const credentialsSubject = new ReplaySubject<CredentialsCollection>();

--- a/src/utils/ReactHooks.ts
+++ b/src/utils/ReactHooks.ts
@@ -139,6 +139,7 @@ export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
     if (args.onValue != null) {
       args.onValue(v);
     }
+    args.cache.set(args.key, serialize(v));
   };
 
   const serialize = args.serialize || JSON.stringify;
@@ -172,8 +173,6 @@ export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
 
         const loaded = await args.loader();
         setIfActive(loaded);
-
-        await args.cache.set(args.key, serialize(loaded));
       })();
 
       return () => {

--- a/src/utils/ReactHooks.ts
+++ b/src/utils/ReactHooks.ts
@@ -123,6 +123,9 @@ export interface CacheArgs<T> {
   deserialize?: (s: string) => T;
 }
 
+// React Hook that will as quickly as possible return a value from cache and
+// continue to load the value from the source of truth once the useFor window
+// has passed.
 export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
   // We keep the state that's bound together in the same useState so React
   // doesn't trigger renders when setting one but not the other.


### PR DESCRIPTION
Also allow exporting credentials.

Also show loading screen when loading the credentials.

The screen now loads credentials every time the page is loaded. So:

1. We can start caching the value (with or without loading it from the server). I don't think the server will have trouble keeping up with any QPS from loading it this frequently.
2. We can probably remove the refresh button.

Also, there is some stuff about "Requests" that I can't really understand what is happening.