### PR TITLE
Reload liveness check after completing opt in

### DIFF
--- a/src/popup/components/Protocol/index.tsx
+++ b/src/popup/components/Protocol/index.tsx
@@ -25,8 +25,11 @@ function ProtocolState() {
       setPageOverride(
         <SetupInProgress onRetry={() => optInWithMnemonic(mnemonic)} />,
       );
+
       await getProtocolOptIn().optIn(mnemonic);
-      serviceOptedIn.setValue(true);
+      serviceOptedIn.reload();
+      completedLiveness.reload();
+
       setPageOverride(
         <SetupSuccess onContinue={() => setPageOverride(null)} />,
       );
@@ -41,7 +44,10 @@ function ProtocolState() {
   const doLiveness = async () => {
     try {
       setPageOverride(<SetupInProgress onRetry={doLiveness} />);
+
       await getProtocolOptIn().postOptInLiveness();
+      completedLiveness.reload();
+
       setPageOverride(null);
     } catch (e) {
       console.error(e);

--- a/src/utils/ReactHooks.ts
+++ b/src/utils/ReactHooks.ts
@@ -34,22 +34,20 @@ export function useLoadedState<T>(loader: () => Promise<T>): Load<T> {
     };
   }, [memoLoader, loaded]);
 
-  const setLoadAndValue = (value: T) => setLoadedValue([true, value]);
   const reload = () => setLoadedValue([false, null]);
   if (loaded) {
-    return new Loaded<T>(value!, setLoadAndValue, reload);
+    return new Loaded<T>(value!, reload);
   } else {
-    return new Loading<T>(setLoadAndValue, reload);
+    return new Loading(reload);
   }
 }
 
-type Load<T> = Loading<T> | Loaded<T>;
+type Load<T> = Loading | Loaded<T>;
 
-class Loading<T> {
+class Loading {
   isLoaded: false = false;
 
   constructor(
-    public readonly setValue: (t: T) => void,
     public readonly reload: () => void,
   ) {}
 
@@ -63,7 +61,6 @@ class Loaded<T> {
 
   constructor(
     public readonly value: T,
-    public readonly setValue: (t: T) => void,
     public readonly reload: () => void,
   ) {}
 
@@ -194,17 +191,17 @@ export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
 
   const reload = () => setLoadedValue([false, null]);
   if (loaded) {
-    return new Loaded(value as T, setValue, reload);
+    return new Loaded(value as T, reload);
   } else {
     const immediateCache = args.cache.getImmediate(args.key);
     if (immediateCache == null) {
-      return new Loading(setValue, reload);
+      return new Loading(reload);
     } else {
       const deserialized = deserialize(immediateCache[1]);
       // Use setTimeout since we are not allowed to set a state value during
       // a render.
       setTimeout(() => setValue(deserialized));
-      return new Loaded(deserialized, setValue, reload);
+      return new Loaded(deserialized, reload);
     }
   }
 }

--- a/src/utils/ReactHooks.ts
+++ b/src/utils/ReactHooks.ts
@@ -47,9 +47,7 @@ type Load<T> = Loading | Loaded<T>;
 class Loading {
   isLoaded: false = false;
 
-  constructor(
-    public readonly reload: () => void,
-  ) {}
+  constructor(public readonly reload: () => void) {}
 
   unwrapOrDefault<U>(def: U): U {
     return def;
@@ -59,10 +57,7 @@ class Loading {
 class Loaded<T> {
   isLoaded: true = true;
 
-  constructor(
-    public readonly value: T,
-    public readonly reload: () => void,
-  ) {}
+  constructor(public readonly value: T, public readonly reload: () => void) {}
 
   unwrapOrDefault<U>(_def: U): T {
     return this.value;

--- a/src/utils/ReactHooks.ts
+++ b/src/utils/ReactHooks.ts
@@ -9,10 +9,9 @@ import { Observable } from "rxjs";
 export function useLoadedState<T>(loader: () => Promise<T>): Load<T> {
   // We keep the state that's bound together in the same useState so React
   // doesn't trigger renders when setting one but not the other.
-  const [[loaded, value], setLoadedValue] = useState<[boolean, T | null]>([
-    false,
-    null,
-  ]);
+  const [[loaded, value], setLoadedValue] = useState<[true, T] | [false, null]>(
+    [false, null],
+  );
 
   // The common case is to only want to call the loader once, so we memoize it
   // for the user to prevent all users from having to do that themselves.
@@ -36,10 +35,11 @@ export function useLoadedState<T>(loader: () => Promise<T>): Load<T> {
   }, [memoLoader, loaded]);
 
   const setLoadAndValue = (value: T) => setLoadedValue([true, value]);
+  const reload = () => setLoadedValue([false, null]);
   if (loaded) {
-    return new Loaded<T>(value!, setLoadAndValue);
+    return new Loaded<T>(value!, setLoadAndValue, reload);
   } else {
-    return new Loading<T>(setLoadAndValue);
+    return new Loading<T>(setLoadAndValue, reload);
   }
 }
 
@@ -48,7 +48,10 @@ type Load<T> = Loading<T> | Loaded<T>;
 class Loading<T> {
   isLoaded: false = false;
 
-  constructor(public readonly setValue: (t: T) => void) {}
+  constructor(
+    public readonly setValue: (t: T) => void,
+    public readonly reload: () => void,
+  ) {}
 
   unwrapOrDefault<U>(def: U): U {
     return def;
@@ -61,6 +64,7 @@ class Loaded<T> {
   constructor(
     public readonly value: T,
     public readonly setValue: (t: T) => void,
+    public readonly reload: () => void,
   ) {}
 
   unwrapOrDefault<U>(_def: U): T {
@@ -129,10 +133,9 @@ export interface CacheArgs<T> {
 export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
   // We keep the state that's bound together in the same useState so React
   // doesn't trigger renders when setting one but not the other.
-  const [[loaded, value], setLoadedValue] = useState<[boolean, T | null]>([
-    false,
-    null,
-  ]);
+  const [[loaded, value], setLoadedValue] = useState<[true, T] | [false, null]>(
+    [false, null],
+  );
 
   const setValue = (v: T) => {
     setLoadedValue([true, v]);
@@ -147,6 +150,8 @@ export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
 
   useEffect(
     () => {
+      if (loaded) return;
+
       let active = true;
 
       const setIfActive = (v: T) => {
@@ -184,21 +189,22 @@ export function useCachedState<T>(args: CacheArgs<T>): Load<T> {
     // arguments effectively memoizes the input object so the user doesn't
     // have to.
     // eslint-disable-next-line
-    [],
+    [loaded],
   );
 
+  const reload = () => setLoadedValue([false, null]);
   if (loaded) {
-    return new Loaded(value as T, setValue);
+    return new Loaded(value as T, setValue, reload);
   } else {
     const immediateCache = args.cache.getImmediate(args.key);
     if (immediateCache == null) {
-      return new Loading(setValue);
+      return new Loading(setValue, reload);
     } else {
       const deserialized = deserialize(immediateCache[1]);
       // Use setTimeout since we are not allowed to set a state value during
       // a render.
       setTimeout(() => setValue(deserialized));
-      return new Loaded(deserialized, setValue);
+      return new Loaded(deserialized, setValue, reload);
     }
   }
 }


### PR DESCRIPTION
This fixes the UI showing that you need to complete liveness after opting in when you do not need to complete liveness.