### PR TITLE
Harden token use

### DIFF
--- a/src/services/CatfishService/index.ts
+++ b/src/services/CatfishService/index.ts
@@ -29,7 +29,7 @@ export class CatfishService {
   }
 
   public async refreshResourceServerToken() {
-    const token = this.fractalAccount.getCatfishToken();
+    const token = await this.fractalAccount.getCatfishToken();
 
     const { user_id } = await this.callApi("account/me", "GET", null, {
       authorization: `Bearer ${token}`,
@@ -43,11 +43,11 @@ export class CatfishService {
     return access_token;
   }
 
-  public resourceServerAccessToken({ username }: { username: string }) {
-    const token = this.fractalAccount.getCatfishToken();
-    const scopes = this.fractalAccount.getScopes();
+  public async resourceServerAccessToken({ username }: { username: string }) {
+    const token = await this.fractalAccount.getCatfishToken();
+    const scopes = await this.fractalAccount.getScopes();
 
-    return this.callApi(
+    return await this.callApi(
       "oauth/token",
       "POST",
       JSON.stringify({

--- a/src/services/FractalAccount.ts
+++ b/src/services/FractalAccount.ts
@@ -12,7 +12,7 @@ interface Tokens {
 export class NotConnectedError extends Error {
   constructor(message?: string) {
     super(message);
-    this.name = 'NotConnectedError';
+    this.name = "NotConnectedError";
   }
 }
 

--- a/src/services/FractalAccount.ts
+++ b/src/services/FractalAccount.ts
@@ -9,7 +9,12 @@ interface Tokens {
   scopes: string;
 }
 
-export class NotConnectedError extends Error {}
+export class NotConnectedError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'NotConnectedError';
+  }
+}
 
 const NEXT_TOKENS_KEY = "fractal-account-connector/will-accept-next-tokens";
 const TOKENS_KEY = "fractal-account-connector/tokens";
@@ -74,31 +79,29 @@ export class FractalAccountConnector extends MultiContext {
     await this.setTokens(tokens);
   }
 
-  getMegalodonToken() {
-    if (this.tokens == null) throw new NotConnectedError();
+  async getMegalodonToken() {
+    return (await this.requireTokens()).megalodon;
+  }
 
-    return this.tokens.megalodon;
+  private async requireTokens() {
+    const t = await this.getTokens();
+    if (t == null) throw new NotConnectedError();
+    return t;
   }
 
   async setMegalodonToken(token: string) {
-    if (this.tokens == null) throw new NotConnectedError();
-
     await this.storage.setItem(
       TOKENS_KEY,
-      JSON.stringify({ ...this.tokens, megalodon: token }),
+      JSON.stringify({ ...(await this.requireTokens()), megalodon: token }),
     );
   }
 
-  getCatfishToken() {
-    if (this.tokens == null) throw new NotConnectedError();
-
-    return this.tokens.catfish;
+  async getCatfishToken() {
+    return (await this.requireTokens()).catfish;
   }
 
-  getScopes() {
-    if (this.tokens == null) throw new NotConnectedError();
-
-    return this.tokens.scopes;
+  async getScopes() {
+    return (await this.requireTokens()).scopes;
   }
 
   async clearTokens() {

--- a/src/services/MaguroService/index.ts
+++ b/src/services/MaguroService/index.ts
@@ -19,7 +19,7 @@ export class MaguroService {
   ): Promise<Record<string, string>> {
     if (headers["authorization"]) return headers;
 
-    const token = this.fractalAccount.getMegalodonToken();
+    const token = await this.fractalAccount.getMegalodonToken();
 
     headers["authorization"] = `Bearer ${token}`;
     headers["content-type"] = "application/json";

--- a/src/services/MegalodonService/index.ts
+++ b/src/services/MegalodonService/index.ts
@@ -12,12 +12,12 @@ export class MegalodonService {
     private readonly catfish: CatfishService,
   ) {}
 
-  private ensureAuthorization(
+  private async ensureAuthorization(
     headers: Record<string, string>,
-  ): Record<string, string> {
+  ): Promise<Record<string, string>> {
     if (headers["authorization"]) return headers;
 
-    const token = this.fractalAccount.getMegalodonToken();
+    const token = await this.fractalAccount.getMegalodonToken();
 
     headers["authorization"] = `Bearer ${token}`;
     headers["content-type"] = "application/json";
@@ -31,7 +31,7 @@ export class MegalodonService {
     body?: RequestInit["body"],
     headers?: RequestInit["headers"],
   ): Promise<any> {
-    const headersWithAuth = this.ensureAuthorization(
+    const headersWithAuth = await this.ensureAuthorization(
       (headers as Record<string, string>) || {},
     );
     return this.callApi(route, method, body, headersWithAuth);


### PR DESCRIPTION
This should prevent an error I've seen occasionally but cannot consistently reproduce. It seems the background script sometimes fails to read the tokens when they are acquired. Loading them from storage on every access should prevent that error.