### PR TITLE
Reduce sweep amount by fee

### DIFF
--- a/src/popup/components/Protocol/SendTokens.tsx
+++ b/src/popup/components/Protocol/SendTokens.tsx
@@ -14,14 +14,14 @@ import {
 
 import { getProtocolService } from "@services/Factory";
 
-const FCL_UNIT = 10 ** 12;
+const FCL_UNIT = BigInt(10 ** 12);
 
 export function SendTokens(props: { onFinish: () => void }) {
   const [page, setPage] = useState<"specify" | "confirm" | JSX.Element>(
     "specify",
   );
 
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState(BigInt(0));
   const [destination, setDestination] = useState("");
 
   const [loading, setLoading] = useState(false);
@@ -66,12 +66,12 @@ export function SendTokens(props: { onFinish: () => void }) {
 function SpecifySend(props: {
   address: string;
   onChangeAddress: (a: string) => void;
-  amount: number;
-  onChangeAmount: (a: number) => void;
+  amount: bigint;
+  onChangeAmount: (a: bigint) => void;
   onContinue: () => void;
 }) {
   const validAddress = isValidAddress(props.address);
-  const validAmount = props.amount > 0;
+  const validAmount = props.amount > BigInt(0);
   const isValid = validAddress && validAmount;
 
   return (
@@ -96,11 +96,11 @@ function SpecifySend(props: {
             label="Amount"
             type="number"
             value={
-              props.amount === 0 ? "" : (props.amount / FCL_UNIT).toString()
+              props.amount === BigInt(0) ? "" : (props.amount / FCL_UNIT).toString()
             }
             onChange={(e) => {
               props.onChangeAmount(
-                Math.floor(Number(e.target.value) * FCL_UNIT),
+                BigInt(e.target.value) * FCL_UNIT,
               );
             }}
           />
@@ -136,7 +136,7 @@ function isValidAddress(address: string) {
 
 function ConfirmSend(props: {
   address: string;
-  amount: number;
+  amount: bigint;
   onConfirm: () => void;
   onCancel: () => void;
   loading: boolean;

--- a/src/popup/components/Protocol/SendTokens.tsx
+++ b/src/popup/components/Protocol/SendTokens.tsx
@@ -96,12 +96,12 @@ function SpecifySend(props: {
             label="Amount"
             type="number"
             value={
-              props.amount === BigInt(0) ? "" : (props.amount / FCL_UNIT).toString()
+              props.amount === BigInt(0)
+                ? ""
+                : (props.amount / FCL_UNIT).toString()
             }
             onChange={(e) => {
-              props.onChangeAmount(
-                BigInt(e.target.value) * FCL_UNIT,
-              );
+              props.onChangeAmount(BigInt(e.target.value) * FCL_UNIT);
             }}
           />
         </HorizontalContainer>

--- a/src/popup/components/Protocol/SweepTokens.tsx
+++ b/src/popup/components/Protocol/SweepTokens.tsx
@@ -14,7 +14,7 @@ import {
 
 import { getProtocolService } from "@services/Factory";
 
-const FCL_UNIT = 10 ** 12;
+const FCL_UNIT = BigInt(10 ** 12);
 
 export function SweepTokens(props: { onFinish: () => void }) {
   const [page, setPage] = useState<JSX.Element | null>(null);
@@ -55,7 +55,7 @@ function SpecifyFrom(props: {
   const amount = balance
     .map((b) => {
       if (b == null) return "?";
-      return (b.free.toNumber() / FCL_UNIT).toString();
+      return (b.free.toBigInt() / FCL_UNIT).toString();
     })
     .unwrapOrDefault("?");
 

--- a/src/services/ProtocolService/index.ts
+++ b/src/services/ProtocolService/index.ts
@@ -208,7 +208,10 @@ export class ProtocolService {
     return signer;
   }
 
-  async sendToAddress(address: string, amount: number|bigint): Promise<string> {
+  async sendToAddress(
+    address: string,
+    amount: number | bigint,
+  ): Promise<string> {
     const api = await this.api;
     const txn = api.tx.balances.transfer(address, amount);
     const watcher = TxnWatcher.signAndSend(txn as any, this.requireSigner());
@@ -227,15 +230,19 @@ export class ProtocolService {
       const signer = this.createSigner(mnemonic);
       const balance = (await this.getBalance(signer.address)).free.toBigInt();
 
-      const prospectiveTxn = api.tx.balances.transfer(this.address(), balance);
-      const fee = (await prospectiveTxn.paymentInfo(signer)).partialFee;
+      const fee = (
+        await api.tx.balances
+          .transfer(this.address(), balance)
+          .paymentInfo(signer)
+      ).partialFee;
 
-      const txn = api.tx.balances.transfer(this.address(), balance - fee.toBigInt());
-      const { hash } = await TxnWatcher.signAndSend(
-        txn as any,
-        signer,
-        { fee } as any
-      ).inBlock();
+      const txn = api.tx.balances.transfer(
+        this.address(),
+        balance - fee.toBigInt(),
+      );
+      const { hash } = await TxnWatcher.signAndSend(txn as any, signer, {
+        fee,
+      } as any).inBlock();
       return hash;
     });
   }


### PR DESCRIPTION
Also use BigInt everywhere we're dealing with balances directly, so we can handle sending more than ~9007 tokens.