### PR TITLE
Limit resource server token scopes to user.permanent_id:read user.verification:read

### DIFF
--- a/src/redux/stores/application/reducers/auth/index.js
+++ b/src/redux/stores/application/reducers/auth/index.js
@@ -6,7 +6,6 @@ const types = mirrorCreator([
   "SET_BACKEND_SESSIONS",
   "SET_BACKEND_CATFISH_SESSION",
   "SET_BACKEND_MEGALODON_SESSION",
-  "SET_BACKEND_SCOPES",
   "SIGN_IN_REQUEST",
   "SIGN_IN_PENDING",
   "SIGN_IN_FAILED",
@@ -26,7 +25,6 @@ const creators = createActions(
   types.SET_BACKEND_SESSIONS,
   types.SET_BACKEND_CATFISH_SESSION,
   types.SET_BACKEND_MEGALODON_SESSION,
-  types.SET_BACKEND_SCOPES,
   types.SIGN_IN_REQUEST,
   types.SIGN_IN_PENDING,
   types.SIGN_IN_FAILED,
@@ -60,7 +58,6 @@ const initialState = {
   sessions: {
     catfish: "",
     megalodon: "",
-    scopes: "",
   },
   hashedPassword: "",
   loggedIn: false,
@@ -94,11 +91,6 @@ export const reducer = handleActions(
           ...state.sessions,
           megalodon,
         },
-      }),
-    [types.SET_BACKEND_SCOPES]: (state, { payload: scopes }) =>
-      Object.freeze({
-        ...state,
-        scopes,
       }),
     [types.SIGN_IN_REQUEST]: (state) =>
       Object.freeze({

--- a/src/scripts/sdk/InpageProvider/connection/callbacks/FractalCallbacks/index.ts
+++ b/src/scripts/sdk/InpageProvider/connection/callbacks/FractalCallbacks/index.ts
@@ -6,7 +6,6 @@ const MEGALODON_SESSION_KEY = "megalodon_token";
 const getBackendSessions = () => ({
   catfish: localStorage.getItem(CATFISH_SESSION_KEY),
   megalodon: localStorage.getItem(MEGALODON_SESSION_KEY),
-  scopes: localStorage.getItem(`${MEGALODON_SESSION_KEY}-scopes`),
 });
 
 const Callbacks = {

--- a/src/services/CatfishService/index.ts
+++ b/src/services/CatfishService/index.ts
@@ -3,6 +3,8 @@ import HttpService from "@services/HttpService";
 import { ERRORS_CATFISH_TOKEN_EXPIRED } from "./Errors";
 import { FractalAccountConnector } from "@services/FractalAccount";
 
+const RESOURCE_SERVER_TOKEN_SCOPES = "user.verification:read";
+
 export class CatfishService {
   constructor(private readonly fractalAccount: FractalAccountConnector) {}
 
@@ -45,7 +47,6 @@ export class CatfishService {
 
   public async resourceServerAccessToken({ username }: { username: string }) {
     const token = await this.fractalAccount.getCatfishToken();
-    const scopes = await this.fractalAccount.getScopes();
 
     return await this.callApi(
       "oauth/token",
@@ -53,7 +54,7 @@ export class CatfishService {
       JSON.stringify({
         grant_type: "password",
         password: token,
-        scope: scopes,
+        scope: RESOURCE_SERVER_TOKEN_SCOPES,
         username,
       }),
       { "Content-Type": "application/json" },

--- a/src/services/CatfishService/index.ts
+++ b/src/services/CatfishService/index.ts
@@ -3,7 +3,10 @@ import HttpService from "@services/HttpService";
 import { ERRORS_CATFISH_TOKEN_EXPIRED } from "./Errors";
 import { FractalAccountConnector } from "@services/FractalAccount";
 
-const RESOURCE_SERVER_TOKEN_SCOPES = "user.verification:read";
+const RESOURCE_SERVER_TOKEN_SCOPES = [
+  "user.permanent_id:read",
+  "user.verification:read",
+].join(" ");
 
 export class CatfishService {
   constructor(private readonly fractalAccount: FractalAccountConnector) {}

--- a/src/services/FractalAccount.ts
+++ b/src/services/FractalAccount.ts
@@ -6,7 +6,6 @@ import { Storage } from "@utils/StorageArray";
 interface Tokens {
   catfish: string;
   megalodon: string;
-  scopes: string;
 }
 
 export class NotConnectedError extends Error {
@@ -71,11 +70,10 @@ export class FractalAccountConnector extends MultiContext {
 
     const catfish = localStorage.getItem(catfishSessionKey);
     const megalodon = localStorage.getItem(megalodonSessionKey);
-    const scopes = localStorage.getItem(`${megalodonSessionKey}-scopes`);
 
-    if (!catfish || !megalodon || !scopes) return;
+    if (!catfish || !megalodon) return;
 
-    const tokens = { catfish, megalodon, scopes };
+    const tokens = { catfish, megalodon };
     await this.setTokens(tokens);
   }
 
@@ -98,10 +96,6 @@ export class FractalAccountConnector extends MultiContext {
 
   async getCatfishToken() {
     return (await this.requireTokens()).catfish;
-  }
-
-  async getScopes() {
-    return (await this.requireTokens()).scopes;
   }
 
   async clearTokens() {


### PR DESCRIPTION
Fixes #193.

This PR changes the logic behind the access token scopes for the resource server (megalodon).
**As is:**
1. `megalodon_token-scopes` are saved in localStorage when the first access token is extracted from Fractal ID
2. `megalodon_token-scopes` are re-used when requesting new access tokens
If the scopes that were extracted from Fractal ID become unavailable in the future, the extension will continue to request a token with these invalid scopes.

**To be:**
1. The first `megalodon_token` extracted from Fractal ID will contain whatever scopes Fractal ID is using (currently almost all the available scopes including the relevant ones `user.permanent_id:read user.verification:read`)
2. Once this token expires, the subsequent tokens will be requested with the bare minimum scopes `user.permanent_id:read user.verification:read`